### PR TITLE
with() does not escape correctly

### DIFF
--- a/src/Concise/Mock/ClassCompiler.php
+++ b/src/Concise/Mock/ClassCompiler.php
@@ -139,7 +139,7 @@ EOF;
 					$defaultActionCode = $action->getActionCode();
 				}
 				else {
-					$args = str_replace('"', '\\"', json_encode($rule['with']));
+					$args = addslashes(json_encode($rule['with']));
 					$actionCode .= <<<EOF
 if(json_encode(func_get_args()) == "$args") {
 	{$action->getActionCode()}

--- a/tests/Concise/Mock/MockBuilderWithTest.php
+++ b/tests/Concise/Mock/MockBuilderWithTest.php
@@ -49,4 +49,12 @@ class MockBuilderWithTest extends TestCase
 		$mock->myMethod('a');
 		$this->assert($mock->myMethod('a'), equals, 'foo');
 	}
+
+	public function testStringsInExpectedArgumentsMustBeEscapedCorrectly()
+	{
+		$mock = $this->mock('Concise\Mock\MockBuilderWithStub')
+		             ->stub('myMethod')->with('"foo"')
+		             ->done();
+		$this->assert($mock->myMethod('"foo"'), is_null);
+	}
 }


### PR DESCRIPTION
With this:

``` php
return $this->mock('Kounta\MYOB\AccountRight\AccountRightClient')
            ->disableConstructor()
            ->expect('safeRequest')->with($requestUrl, 'POST', $data)
            ->done();
```

Generates invalid PHP code:

``` php
if(json_encode(func_get_args()) == "[\"ABCD\/Contact\/\",\"POST\",\"{\\"foo\\":\\"bar\\"}\"]") {
```
