### PR TITLE
Cleanup left bar when printing issues

### DIFF
--- a/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
@@ -32,7 +32,8 @@ class RenderIssue
         $top = "$issueNumber. " . get_class($test) . '::' . $test->getName() . "\n\n";
         $message = $e->getMessage() . "\n\n";
         $message .= $this->prefixLines("\033[90m", $this->traceSimplifier->render($e->getTrace())) . "\033[0m";
+        $pad = str_repeat(' ', strlen($issueNumber));
 
-        return $top . $this->prefixLines($c("  ")->highlight($colors[$status]) . ' ', rtrim($message));
+        return $top . $this->prefixLines($c("  ")->highlight($colors[$status]) . $pad, rtrim($message));
     }
 }

--- a/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
@@ -52,12 +52,12 @@ class RenderIssueTest extends TestCase
                     ->done();
     }
 
-    protected function render($status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE)
+    protected function render($status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, $issueNumber = 0)
     {
         $simplifier = $this->getTraceSimplifier();
         $issue = new RenderIssue($simplifier);
 
-        return $issue->render($status, 0, $this->test, $this->exception);
+        return $issue->render($status, $issueNumber, $this->test, $this->exception);
     }
 
     public function testWillRenderSimplifiedTraceUnderneathTheTitle()
@@ -94,5 +94,11 @@ class RenderIssueTest extends TestCase
     {
         $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED);
         $this->assert($result, contains_string, "\033[44m  \033[0m ");
+    }
+
+    public function testWhenIssueNumberGoesAbove10ExtraPaddingWillBeProvidedToKeepItAligned()
+    {
+        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $this->assert($result, contains_string, "\033[41m  \033[0m  ");
     }
 }


### PR DESCRIPTION
In the concise executable when it reaches 10 messages the coloured bar on the left gets thicker. It should pad with spaces so that they remain the same thickness.
