### PR TITLE
RenderIssue bug

### DIFF
--- a/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
@@ -2,10 +2,10 @@
 
 namespace Concise\Console\ResultPrinter\Utilities;
 
-use PHPUnit_Framework_TestCase;
 use Exception;
 use Colors\Color;
 use Concise\Console\Theme\DefaultTheme;
+use PHPUnit_Framework_Test;
 
 class RenderIssue
 {
@@ -24,7 +24,7 @@ class RenderIssue
         return $prefix . str_replace("\n", "\n$prefix", $lines);
     }
 
-    public function render($status, $issueNumber, PHPUnit_Framework_TestCase $test, Exception $e)
+    public function render($status, $issueNumber, PHPUnit_Framework_Test $test, Exception $e)
     {
         $c = new Color();
         $theme = new DefaultTheme();

--- a/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
@@ -101,4 +101,13 @@ class RenderIssueTest extends TestCase
         $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "\033[41m  \033[0m  ");
     }
+
+    public function testCanAcceptATestSuite()
+    {
+        $this->test = $this->mock('\PHPUnit_Framework_TestSuite')->disableConstructor()
+                           ->stub(array('getName' => 'foo'))
+                           ->done();
+        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $this->assert($result, contains_string, "foo");
+    }
 }


### PR DESCRIPTION
```
PHP Catchable fatal error:  Argument 3 passed to Concise\Console\ResultPrinter\Utilities\RenderIssue::render() must be an instance of PHPUnit_Framework_TestCase, instance of PHPUnit_Framework_TestSuite given, called in /mnt/hgfs/git/kounta/vendor/elliotchance/concise/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php on line 78 and defined in /mnt/hgfs/git/kounta/vendor/elliotchance/concise/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php on line 27
```
