### PR TITLE
Bug with with() using sprint()

### DIFF
--- a/src/Concise/TestCase.php
+++ b/src/Concise/TestCase.php
@@ -124,7 +124,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $args = $this->renderArguments($rule['with']);
         $converter = new NumberToTimesConverter();
         $msg = sprintf(
-            "Expected $method($args) to be called %s, but it was called %s.",
+            "Expected $method(%s) to be called %s, but it was called %s.",
+            $args,
             $converter->convert($rule['times']),
             $converter->convert($actualTimes)
         );

--- a/tests/Concise/Mock/MockBuilderFailuresTest.php
+++ b/tests/Concise/Mock/MockBuilderFailuresTest.php
@@ -18,6 +18,7 @@ class MockBuilderFailuresTest extends TestCase
         'testMoreTimesThanExpected' => 'Expected myMethod("foo") to be called twice, but it was called 3 times.',
         'testExpectionThatIsNeverCalledWillFail' => 'Expected myMethod("foo") to be called once, but it was called never.',
         'testExpectionMustBeCalledTheRequiredAmountOfTimes' => 'Expected myMethod("foo") to be called twice, but it was called once.',
+        'testWithArgumentsMayContainPercentageThatWasntCalled' => 'Expected myMethod("%d") to be called once, but it was called never.',
     );
 
     public function testFailedToFulfilExpectationWillThrowException()
@@ -91,6 +92,13 @@ class MockBuilderFailuresTest extends TestCase
         $this->mock->myMethod('foo');
         $this->mock->myMethod('foo');
         $this->mock->myMethod('foo');
+    }
+
+    public function testWithArgumentsMayContainPercentageThatWasntCalled()
+    {
+        $mock = $this->mock('\Concise\Mock\Mock1')
+                     ->expects('myMethod')->with('%d')
+                     ->done();
     }
 
     protected function onNotSuccessfulTest(\Exception $e)


### PR DESCRIPTION
`Concise\TestCase::validateSingleWith()`, must be

``` php
        $msg = sprintf(
            "Expected $method(%s) to be called %s, but it was called %s.",
            $args,
            $converter->convert($rule['times']),
            $converter->convert($actualTimes)
        );
```
