### PR TITLE
Missing diffs for assertEquals()

### DIFF
--- a/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
@@ -6,6 +6,7 @@ use Exception;
 use Colors\Color;
 use Concise\Console\Theme\DefaultTheme;
 use PHPUnit_Framework_Test;
+use PHPUnit_Framework_ExpectationFailedException;
 
 class RenderIssue
 {
@@ -31,8 +32,13 @@ class RenderIssue
         $colors = $theme->getTheme();
         $color = $colors[$status];
         $top = "$issueNumber. " . $c(get_class($test) . '::' . $test->getName())->$color . "\n\n";
-        $message = $e->getMessage() . "\n\n";
-        $message .= $this->prefixLines("\033[90m", $this->traceSimplifier->render($e->getTrace())) . "\033[0m";
+        $message = $e->getMessage() . "\n";
+
+        if ($e instanceof PHPUnit_Framework_ExpectationFailedException) {
+            $message .= $e->getComparisonFailure()->getDiff();
+        }
+
+        $message .= "\n" . $this->prefixLines("\033[90m", $this->traceSimplifier->render($e->getTrace())) . "\033[0m";
         $pad = str_repeat(' ', strlen($issueNumber));
 
         return $top . $this->prefixLines($c("  ")->highlight($colors[$status]) . $pad, rtrim($message));

--- a/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
@@ -122,4 +122,15 @@ class RenderIssueTest extends TestCase
         $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "foo");
     }
+
+    public function testPHPUnitDiffsAreShown()
+    {
+        $failure = $this->mock('SebastianBergmann\Comparator\ComparisonFailure', array('foo', 'bar', 'foo', 'bar'))
+                        ->expect('getDiff')->andReturn('foobar')
+                        ->done();
+        $this->exception = new \PHPUnit_Framework_ExpectationFailedException('', $failure);
+
+        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $this->assert($result, contains_string, "foobar");
+    }
 }


### PR DESCRIPTION
When PHPUnit fails to compare two values it prints out a diff, this diff is not showing up in the concise executable.
