### PR TITLE
Strings that are the same as function names are mistaken as callable

### DIFF
--- a/src/Concise/Services/DataTypeChecker.php
+++ b/src/Concise/Services/DataTypeChecker.php
@@ -2,6 +2,8 @@
 
 namespace Concise\Services;
 
+use Closure;
+
 class DataTypeChecker
 {
     /**
@@ -118,7 +120,7 @@ class DataTypeChecker
         if ($this->isAttribute($value)) {
             return $this->getType($this->getAttribute($value->getValue()));
         }
-        if (is_callable($value)) {
+        if ($value instanceof Closure) {
             return 'callable';
         }
 

--- a/tests/Concise/Services/DataTypeCheckerTest.php
+++ b/tests/Concise/Services/DataTypeCheckerTest.php
@@ -48,6 +48,7 @@ class DataTypeCheckerTest extends \Concise\TestCase
             array(array("number"), 12.3),
             array(array("number"), '12.3'),
             array(array("bool"), true),
+            array(array("string"), 'count'),
         );
     }
 


### PR DESCRIPTION
``` php
$this->assert($invoice, has_key, "Date");
```

Delivers the error:

```
Argument 2 (Date) must be int or string.
```
