### PR TITLE
Print JSON expanded

### DIFF
--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -94,10 +94,10 @@ class DefaultResultPrinter extends AbstractResultPrinter
                 }
         }
 
-        ++$this->issueNumber;
         $renderIssue = new RenderIssue();
         $message = $renderIssue->render($status, $this->issueNumber, $test, $e);
         $this->appendTextAbove("$message\n\n");
+        ++$this->issueNumber;
     }
 
     public function appendTextAbove($text)

--- a/src/Concise/Services/ValueRenderer.php
+++ b/src/Concise/Services/ValueRenderer.php
@@ -30,38 +30,49 @@ class ValueRenderer
             return (string) $c($value)->{$this->theme['value.float']};
         }
 
-        return (string) $c($value)->{$this->theme['value.string']};
+        $lines = explode("\n", $value);
+        $string = array();
+        foreach ($lines as $line) {
+            $string[] = (string) $c($line)->{$this->theme['value.string']};
+        }
+
+        return implode("\n", $string);
     }
 
-    protected function jsonEncodeCallback(array $values, Closure $callback)
+    protected function jsonEncodeCallback(array $values, $depth, Closure $callback)
     {
         $r = '';
         foreach ($values as $k => $v) {
             if ($r) {
-                $r .= ',';
+                $r .= ",\n";
             }
-            $r .= $callback($k, $v);
+            $r .= $this->createIndent($depth) . $callback($k, $v);
         }
 
         return $r;
+    }
+
+    protected function createIndent($depth)
+    {
+        return str_repeat('  ', $depth);
     }
 
     protected function jsonEncode($value, $depth)
     {
         $self = $this;
         if (is_object($value) || (is_array($value) && $this->isAssociativeArray($value))) {
-            $r = $this->jsonEncodeCallback((array) $value, function ($k, $v) use ($depth, $self) {
+            $r = $this->jsonEncodeCallback((array) $value, $depth + 1, function ($k, $v) use ($depth, $self) {
                 return $self->colorize("\"$k\"") . ':' . $self->render($v, false, $depth + 1);
             });
 
-            return "{" . $r . "}";
+            return "{\n" . $r . "\n" . $this->createIndent($depth) . "}";
         }
 
-        $r = $this->jsonEncodeCallback((array) $value, function ($k, $v) use ($depth, $self) {
+        $r = $this->jsonEncodeCallback((array) $value, $depth + 1, function ($k, $v) use ($depth, $self) {
             return $self->render($v, false, $depth + 1);
         });
 
-        return "[$r]";
+        return "[\n$r\n" . $this->createIndent($depth) . "]";
     }
 
     protected function isAssociativeArray(array $a)

--- a/tests/Concise/Mock/MockBuilderFailuresTest.php
+++ b/tests/Concise/Mock/MockBuilderFailuresTest.php
@@ -19,8 +19,8 @@ class MockBuilderFailuresTest extends TestCase
         'testExpectionThatIsNeverCalledWillFail' => 'Expected myMethod("foo") to be called once, but it was called never.',
         'testExpectionMustBeCalledTheRequiredAmountOfTimes' => 'Expected myMethod("foo") to be called twice, but it was called once.',
         'testWithArgumentsMayContainPercentageThatWasntCalled' => 'Expected myMethod("%d") to be called once, but it was called never.',
-        'testWithArgumentsWillNotMistakeAnArrayForACallback' => 'Expected myMethod(["DateTime","getLastErrors"]) to be called once, but it was called never.',
-        'testWithArgumentsUsingDifferentCallback' => 'Expected myMethod(["DateTime","__set_state"]) to be called once, but it was called never.',
+        'testWithArgumentsWillNotMistakeAnArrayForACallback' => "Expected myMethod([\n  \"DateTime\",\n  \"getLastErrors\"\n]) to be called once, but it was called never.",
+        'testWithArgumentsUsingDifferentCallback' => "Expected myMethod([\n  \"DateTime\",\n  \"__set_state\"\n]) to be called once, but it was called never.",
         'testAbstractMethodOnANiceMockThatHasNoActionWillThrowException' => 'myMethod() is abstract and has no associated action.',
         'testAnythingIsRenderedCorrectly' => 'Expected myMethod(<ANYTHING>, "foo") to be called once, but it was called never.',
     );

--- a/tests/Concise/Services/ValueRendererTest.php
+++ b/tests/Concise/Services/ValueRendererTest.php
@@ -33,14 +33,14 @@ class ValueRendererTest extends \Concise\TestCase
 
     public function testArrayValueRendersAsJson()
     {
-        $this->assert($this->renderer->render(array(123, "abc")), equals, '[123,"abc"]');
+        $this->assert($this->renderer->render(array(123, "abc")), equals, "[\n  123,\n  \"abc\"\n]");
     }
 
     public function testObjectValueRendersAsJson()
     {
         $obj = new \stdClass();
         $obj->a = 123;
-        $this->assert($this->renderer->render($obj), equals, 'stdClass:{"a":123}');
+        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":123\n}");
     }
 
     public function testTrueValueRendersAsTrue()
@@ -165,22 +165,22 @@ class ValueRendererTest extends \Concise\TestCase
         $obj = new \stdClass();
         $obj->a = 123;
         $obj->b = 456;
-        $this->assert($this->renderer->render($obj), equals, 'stdClass:{"a":123,"b":456}');
+        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":123,\n  \"b\":456\n}");
     }
 
     public function testMultipleArrayValuesRendersAsJson()
     {
-        $this->assert($this->renderer->render(array(1, 2)), equals, '[1,2]');
+        $this->assert($this->renderer->render(array(1, 2)), equals, "[\n  1,\n  2\n]");
     }
 
     public function testAssociativeArrayRendersAsJson()
     {
-        $this->assert($this->renderer->render(array('foo' => 'bar')), equals, '{"foo":"bar"}');
+        $this->assert($this->renderer->render(array('foo' => 'bar')), equals, "{\n  \"foo\":\"bar\"\n}");
     }
 
     public function testNumericArrayKeysAlwaysRenderAsStrings()
     {
-        $this->assert($this->renderer->render(array(123 => 'bar')), equals, '{"123":"bar"}');
+        $this->assert($this->renderer->render(array(123 => 'bar')), equals, "{\n  \"123\":\"bar\"\n}");
     }
 
     public function testNestedObjectsHideTypeHint()
@@ -188,7 +188,7 @@ class ValueRendererTest extends \Concise\TestCase
         $obj = new \stdClass();
         $obj->a = new \stdClass();
         $obj->a->b = 456;
-        $this->assert($this->renderer->render($obj), equals, 'stdClass:{"a":{"b":456}}');
+        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":{\n    \"b\":456\n  }\n}");
     }
 
     public function testNullWillBeColoredWhenAThemeIsSpecified()
@@ -220,7 +220,7 @@ class ValueRendererTest extends \Concise\TestCase
                          ->stub(array('getMaximumDepth' => 2))
                          ->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}');
-        $this->assert($renderer->render($obj), equals, 'stdClass:{"a":{"a":...}}');
+        $this->assert($renderer->render($obj), equals, "stdClass:{\n  \"a\":{\n    \"a\":...\n  }\n}");
     }
 
     public function testMaximumDepthStopsRendererFromConsumingTooMuchMemoryForArrays()
@@ -229,7 +229,7 @@ class ValueRendererTest extends \Concise\TestCase
                          ->stub(array('getMaximumDepth' => 2))
                          ->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}', true);
-        $this->assert($renderer->render($obj), equals, '{"a":{"a":...}}');
+        $this->assert($renderer->render($obj), equals, "{\n  \"a\":{\n    \"a\":...\n  }\n}");
     }
 
     public function testRenderAnythingConstant()


### PR DESCRIPTION
If there is a lot of JSON to be printed out on error it appears as one very long coloured string, we should pretty format it so that its easy to read.
