### PR TITLE
Show estimated time

### DIFF
--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -102,7 +102,7 @@ class DefaultResultPrinter extends AbstractResultPrinter
         $formatter = new TimeFormatter();
         $time = ', ' . $formatter->format($this->getSecondsElapsed());
         $remaining = '';
-        if ($this->getSecondsElapsed() > 5 && $this->getRemainingSeconds() > 0) {
+        if ($this->getSecondsElapsed() >= 5 && $this->getRemainingSeconds() > 0) {
             $remaining = ' (' . $formatter->format($this->getRemainingSeconds()) . ' remaining)';
         }
         $counterString = $this->counter->render($this->getTestCount());

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
@@ -264,4 +264,15 @@ class DefaultResultPrinterTest extends TestCase
 
         $this->assert($resultPrinter->getAssertionString(), does_not_contain_string, ' remaining');
     }
+
+    public function testWillShowEstimateOnce5SecondsHaveElapsed()
+    {
+        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
+            ->expose('getAssertionString')
+            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
+            ->get();
+        $this->setProperty($resultPrinter, 'startTime', time() - 5);
+
+        $this->assert($resultPrinter->getAssertionString(), contains_string, ' remaining');
+    }
 }


### PR DESCRIPTION
Concise executable can estimate how long is left in the test suite.

Since not all test times were created equal, at the end of a test suit run it should record the time somewhere in a temporary file so that it can use the data on the next run.
