### PR TITLE
More information when with() conditions fail

### DIFF
--- a/src/Concise/Mock/MockManager.php
+++ b/src/Concise/Mock/MockManager.php
@@ -23,6 +23,11 @@ class MockManager
      */
     protected $callGraph = array();
 
+    /**
+     * @var array
+     */
+    protected $argumentsForCallKey = array();
+
     public function __construct(TestCase $testCase)
     {
         $this->testCase = $testCase;
@@ -40,6 +45,20 @@ class MockManager
         );
     }
 
+    protected function didReceive()
+    {
+        if (0 === count($this->callGraph)) {
+            return '';
+        }
+
+        $r = " Did receive:";
+        $converter = new NumberToTimesConverter();
+        foreach ($this->argumentsForCallKey as $key => $args) {
+            $r .= "\n\n" . $converter->convert($this->callGraph[$key]) . ": {$args['method']}(" . $this->renderArguments($args['args']) . ")";
+        }
+        return $r;
+    }
+
     /**
      * @return null
      */
@@ -51,10 +70,11 @@ class MockManager
         $args = $this->renderArguments($rule['with']);
         $converter = new NumberToTimesConverter();
         $msg = sprintf(
-            "Expected $method(%s) to be called %s, but it was called %s.",
+            "Expected $method(%s) to be called %s, but it was called %s.%s",
             $args,
             $converter->convert($rule['times']),
-            $converter->convert($actualTimes)
+            $converter->convert($actualTimes),
+            $this->didReceive()
         );
         throw new \PHPUnit_Framework_AssertionFailedError($msg);
     }
@@ -75,6 +95,10 @@ class MockManager
         $key = $this->getKeyForCall($methodName, $call, $expected);
         if (!array_key_exists($key, $this->callGraph)) {
             $this->callGraph[$key] = 0;
+            $this->argumentsForCallKey[$key] = array(
+                'method' => $methodName,
+                'args' => $call,
+            );
         }
         ++$this->callGraph[$key];
     }
@@ -94,8 +118,15 @@ class MockManager
         $this->validateSingleWith($rule, $this->callGraph[$key], $method);
     }
 
+    protected function resetCallGraph()
+    {
+        $this->callGraph = array();
+        $this->argumentsForCallKey = array();
+    }
+
     protected function validateExpectation($mock, $method, array $rule)
     {
+        $this->resetCallGraph();
         if (null === $rule['with']) {
             /** @var $instance \Concise\Mock\MockInterface */
             $instance = $mock['instance'];

--- a/tests/Concise/Mock/MockBuilderFailuresTest.php
+++ b/tests/Concise/Mock/MockBuilderFailuresTest.php
@@ -10,19 +10,20 @@ class MockBuilderFailuresTest extends TestCase
 
     protected static $expectedFailures = array(
         'testFailedToFulfilExpectationWillThrowException' => 'Expected myMethod() to be called once, but it was called never.',
-        'testMethodCalledWithWrongArgumentValues' => 'Expected myMethod("foo") to be called once, but it was called never.',
-        'testMissingSecondWithExpectation' => 'Expected myMethod("foo") to be called once, but it was called never.',
-        'testExpectationsRenderMultipleArguments' => 'Expected myMethod("foo", "bar") to be called once, but it was called never.',
+        'testMethodCalledWithWrongArgumentValues' => "Expected myMethod(\"foo\") to be called once, but it was called never. Did receive:\n\nonce: myMethod(\"bar\")",
+        'testMissingSecondWithExpectation' => "Expected myMethod(\"foo\") to be called once, but it was called never. Did receive:\n\nonce: myMethod(\"bar\")",
+        'testExpectationsRenderMultipleArguments' => "Expected myMethod(\"foo\", \"bar\") to be called once, but it was called never. Did receive:\n\nonce: myMethod(\"bar\")",
         'testMissingAllExpectations' => 'Expected myMethod("foo") to be called once, but it was called never.',
-        'testLessTimesThanExpected' => 'Expected myMethod("foo") to be called twice, but it was called once.',
-        'testMoreTimesThanExpected' => 'Expected myMethod("foo") to be called twice, but it was called 3 times.',
+        'testLessTimesThanExpected' => "Expected myMethod(\"foo\") to be called twice, but it was called once. Did receive:\n\nonce: myMethod(\"foo\")",
+        'testMoreTimesThanExpected' => "Expected myMethod(\"foo\") to be called twice, but it was called 3 times. Did receive:\n\n3 times: myMethod(\"foo\")",
         'testExpectionThatIsNeverCalledWillFail' => 'Expected myMethod("foo") to be called once, but it was called never.',
-        'testExpectionMustBeCalledTheRequiredAmountOfTimes' => 'Expected myMethod("foo") to be called twice, but it was called once.',
+        'testExpectionMustBeCalledTheRequiredAmountOfTimes' => "Expected myMethod(\"foo\") to be called twice, but it was called once. Did receive:\n\nonce: myMethod(\"foo\")",
         'testWithArgumentsMayContainPercentageThatWasntCalled' => 'Expected myMethod("%d") to be called once, but it was called never.',
         'testWithArgumentsWillNotMistakeAnArrayForACallback' => "Expected myMethod([\n  \"DateTime\",\n  \"getLastErrors\"\n]) to be called once, but it was called never.",
-        'testWithArgumentsUsingDifferentCallback' => "Expected myMethod([\n  \"DateTime\",\n  \"__set_state\"\n]) to be called once, but it was called never.",
+        'testWithArgumentsUsingDifferentCallback' => "Expected myMethod([\n  \"DateTime\",\n  \"__set_state\"\n]) to be called once, but it was called never. Did receive:\n\nonce: myMethod([\n  \"DateTime\",\n  \"getLastErrors\"\n])",
         'testAbstractMethodOnANiceMockThatHasNoActionWillThrowException' => 'myMethod() is abstract and has no associated action.',
         'testAnythingIsRenderedCorrectly' => 'Expected myMethod(<ANYTHING>, "foo") to be called once, but it was called never.',
+        'testWithFailureWithDifferentArgs' => "Expected myMethod(\"foo\") to be called once, but it was called never. Did receive:\n\nonce: myMethod(\"bar\")",
     );
 
     public function testFailedToFulfilExpectationWillThrowException()
@@ -132,6 +133,18 @@ class MockBuilderFailuresTest extends TestCase
         $mock = $this->mock('\Concise\Mock\Mock1')
                      ->expects('myMethod')->with(self::ANYTHING, 'foo')
                      ->get();
+    }
+
+    /**
+     * @group #157
+     */
+    public function testWithFailureWithDifferentArgs()
+    {
+        $mock = $this->mock('\Concise\Mock\Mock1')
+                     ->expects('myMethod')->with('foo')
+                     ->get();
+
+        $mock->myMethod('bar');
     }
 
     protected function onNotSuccessfulTest(\Exception $e)


### PR DESCRIPTION
If the with() condition isn't met then it reports the method was called never. Which is true, but its ambiguous because it may have been called one or more times under different arguments. Need to print out the way it was called.
