### PR TITLE
Mismatched types need to be more informative

### DIFF
--- a/src/Concise/Assertion.php
+++ b/src/Concise/Assertion.php
@@ -103,6 +103,15 @@ class Assertion
         return $this->matcher;
     }
 
+    protected function throwExceptionForInvalidArgument($arg, $index, $argument)
+    {
+        $renderer = new ValueRenderer();
+        $acceptedTypes = implode(" or ", $arg->getAcceptedTypes());
+        $message = sprintf("Argument %d (%s) must be %s.", $index, $renderer->render($argument),
+            $acceptedTypes);
+        throw new Exception($message);
+    }
+
     /**
      * @param  array $arguments
      * @throws Exception
@@ -122,10 +131,7 @@ class Assertion
             try {
                 $r[] = $checker->check($args[$i]->getAcceptedTypes(), $arguments[$i]);
             } catch (InvalidArgumentException $e) {
-                $acceptedTypes = implode(" or ", $args[$i]->getAcceptedTypes());
-                $message = sprintf("Argument %d (%s) must be %s.", $i + 1, $arguments[$i],
-                    $acceptedTypes);
-                throw new Exception($message);
+                $this->throwExceptionForInvalidArgument($args[$i], $i + 1, $arguments[$i]);
             }
         }
 

--- a/tests/Concise/Syntax/MatcherParserTest.php
+++ b/tests/Concise/Syntax/MatcherParserTest.php
@@ -260,4 +260,13 @@ class MatcherParserTest extends TestCase
         $parser = new MatcherParser();
         $parser->compile(123);
     }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Argument 2 (null) must be regex.
+     */
+    public function testWillUseValueRendererForValuesInExceptionMessages()
+    {
+        $this->assert("abc", does_not_match_regex, null);
+    }
 }


### PR DESCRIPTION
```
Exception: Argument 1 () must be string.
```

Could be more helpful by tell us what we received instead.
