### PR TITLE
Show version name in CLI

### DIFF
--- a/bin/concise
+++ b/bin/concise
@@ -4,9 +4,13 @@
 require_once('vendor/autoload.php');
 
 use Concise\Console\Command;
+use Concise\Version;
 
-$version = new \Concise\Version();
-echo trim("Concise " . $version->getConciseVersion()) . " by Elliot Chance.\n\n";
+$version = new Version();
+$versionNumber = $version->getConciseVersion();
+$versionName = $version->getVersionNameForVersion($versionNumber);
+echo trim("Concise " . $versionNumber . ' ' . $versionName);
+echo " by Elliot Chance.\n\n";
 
 $command = new Command();
 $command->run($_SERVER['argv'], true);

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -50,8 +50,11 @@ class Version
         return $this->getVersionForPackage('elliotchance/concise');
     }
 
-    public function getVersionNameForVersion()
+    public function getVersionNameForVersion($version)
     {
+        if ($version == 'v1.0') {
+            return 'Big Bang';
+        }
         return '';
     }
 }

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -54,6 +54,8 @@ class Version
     {
         if (ltrim($version, 'v') == '1.0') {
             return 'Big Bang';
+        } else if (ltrim($version, 'v') == '1.1') {
+            return 'Dark Matter';
         }
         return '';
     }

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -55,7 +55,12 @@ class Version
         $names = array(
             'Big Bang',
             'Dark Matter',
-            'String Theory'
+            'String Theory',
+            'Supernova',
+            'Quantum',
+            'Antimatter',
+            'Entropy',
+            'Multiverse',
         );
 
         $version = ltrim($version, 'v');

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -52,11 +52,17 @@ class Version
 
     public function getVersionNameForVersion($version)
     {
-        if (ltrim($version, 'v') == '1.0') {
-            return 'Big Bang';
-        } else if (ltrim($version, 'v') == '1.1') {
-            return 'Dark Matter';
+        $names = array(
+            'Big Bang',
+            'Dark Matter',
+            'String Theory'
+        );
+
+        $version = ltrim($version, 'v');
+        if (strlen($version) < 3) {
+            return '';
         }
-        return '';
+
+        return $names[substr($version, 2, 1)];
     }
 }

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -49,4 +49,9 @@ class Version
     {
         return $this->getVersionForPackage('elliotchance/concise');
     }
+
+    public function getVersionNameForVersion()
+    {
+        return '';
+    }
 }

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -52,7 +52,7 @@ class Version
 
     public function getVersionNameForVersion($version)
     {
-        if ($version == 'v1.0') {
+        if (ltrim($version, 'v') == '1.0') {
             return 'Big Bang';
         }
         return '';

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -73,4 +73,16 @@ class VersionTest extends TestCase
             'Big Bang'
         );
     }
+
+    /**
+     * @group #257
+     */
+    public function testVersionDoesNotHaveToIncludePrefixingVCharacter()
+    {
+        $this->assert(
+            $this->version->getVersionNameForVersion('1.0'),
+            equals,
+            'Big Bang'
+        );
+    }
 }

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -17,12 +17,20 @@ class VersionTest extends TestCase
 
     public function testVersionCanBeExtractedForAPackageName()
     {
-        $this->assert($this->version->getVersionForPackage('sebastian/version'), matches_regex, '/^\\d\.\\d+/');
+        $this->assert(
+            $this->version->getVersionForPackage('sebastian/version'),
+            matches_regex,
+            '/^\\d\.\\d+/'
+        );
     }
 
     public function testWeCanEasilyGetTheConciseVersion()
     {
-        $this->assert($this->version->getConciseVersion(), equals, $this->version->getVersionForPackage('elliotchance/concise'));
+        $this->assert(
+            $this->version->getConciseVersion(),
+            equals,
+            $this->version->getVersionForPackage('elliotchance/concise')
+        );
     }
 
     public function testFindingVendorFolder()
@@ -44,5 +52,13 @@ class VersionTest extends TestCase
                         ->expose('findVendorFolder')
                         ->get();
         $this->assert($version->findVendorFolder('/tmp'), is_null);
+    }
+
+    /**
+     * @group #257
+     */
+    public function testVersionNameForUnknownVersionIsBlank()
+    {
+        $this->assert($this->version->getVersionNameForVersion(''), is_blank);
     }
 }

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -60,6 +60,7 @@ class VersionTest extends TestCase
             // Edge cases.
             'unknown version is blank' => array('', ''),
             'version can be prefixed with v' => array('v1.1', 'Dark Matter'),
+            'patch version' => array('1.2.3', 'String Theory'),
 
             // Specific versions.
             array('1.0', 'Big Bang'),

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -54,47 +54,32 @@ class VersionTest extends TestCase
         $this->assert($version->findVendorFolder('/tmp'), is_null);
     }
 
-    /**
-     * @group #257
-     */
-    public function testVersionNameForUnknownVersionIsBlank()
+    public function versionData()
     {
-        $this->assert($this->version->getVersionNameForVersion(''), is_blank);
+        return array(
+            // Edge cases.
+            'unknown version is blank' => array('', ''),
+            'version can be prefixed with v' => array('v1.1', 'Dark Matter'),
+
+            // Specific versions.
+            array('1.0', 'Big Bang'),
+            array('1.1', 'Dark Matter'),
+            array('1.2', 'String Theory'),
+            array('1.3', 'Supernova'),
+            array('1.4', 'Quantum'),
+            array('1.5', 'Antimatter'),
+            array('1.6', 'Entropy'),
+            array('1.7', 'Multiverse'),
+        );
     }
 
     /**
      * @group #257
+     * @dataProvider versionData
      */
-    public function testVersionBigBang()
+    public function testVersionName($version, $expectedName)
     {
-        $name = $this->version->getVersionNameForVersion('v1.0');
-        $this->assert($name, equals, 'Big Bang');
-    }
-
-    /**
-     * @group #257
-     */
-    public function testVersionDoesNotHaveToIncludePrefixingVCharacter()
-    {
-        $name = $this->version->getVersionNameForVersion('1.0');
-        $this->assert($name, equals, 'Big Bang');
-    }
-
-    /**
-     * @group #257
-     */
-    public function testVersionDarkMatter()
-    {
-        $name = $this->version->getVersionNameForVersion('v1.1');
-        $this->assert($name, equals, 'Dark Matter');
-    }
-
-    /**
-     * @group #257
-     */
-    public function testVersionStringTheory()
-    {
-        $name = $this->version->getVersionNameForVersion('v1.2');
-        $this->assert($name, equals, 'String Theory');
+        $name = $this->version->getVersionNameForVersion($version);
+        $this->assert($name, equals, $expectedName);
     }
 }

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -67,11 +67,8 @@ class VersionTest extends TestCase
      */
     public function testVersionBigBang()
     {
-        $this->assert(
-            $this->version->getVersionNameForVersion('v1.0'),
-            equals,
-            'Big Bang'
-        );
+        $name = $this->version->getVersionNameForVersion('v1.0');
+        $this->assert($name, equals, 'Big Bang');
     }
 
     /**
@@ -79,10 +76,16 @@ class VersionTest extends TestCase
      */
     public function testVersionDoesNotHaveToIncludePrefixingVCharacter()
     {
-        $this->assert(
-            $this->version->getVersionNameForVersion('1.0'),
-            equals,
-            'Big Bang'
-        );
+        $name = $this->version->getVersionNameForVersion('1.0');
+        $this->assert($name, equals, 'Big Bang');
+    }
+
+    /**
+     * @group #257
+     */
+    public function testVersionDarkMatter()
+    {
+        $name = $this->version->getVersionNameForVersion('1.1');
+        $this->assert($name, equals, 'Dark Matter');
     }
 }

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -85,7 +85,16 @@ class VersionTest extends TestCase
      */
     public function testVersionDarkMatter()
     {
-        $name = $this->version->getVersionNameForVersion('1.1');
+        $name = $this->version->getVersionNameForVersion('v1.1');
         $this->assert($name, equals, 'Dark Matter');
+    }
+
+    /**
+     * @group #257
+     */
+    public function testVersionStringTheory()
+    {
+        $name = $this->version->getVersionNameForVersion('v1.2');
+        $this->assert($name, equals, 'String Theory');
     }
 }

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -61,4 +61,16 @@ class VersionTest extends TestCase
     {
         $this->assert($this->version->getVersionNameForVersion(''), is_blank);
     }
+
+    /**
+     * @group #257
+     */
+    public function testVersionBigBang()
+    {
+        $this->assert(
+            $this->version->getVersionNameForVersion('v1.0'),
+            equals,
+            'Big Bang'
+        );
+    }
 }


### PR DESCRIPTION
The first line output from the CLI looks like:

    Concise v1.7.1 by Elliot Chance.

It should contain the version name as well:

    Concise v1.7.1 (Multiverse) by Elliot Chance.