### PR TITLE
Result printer not working on iTerm

### DIFF
--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -161,7 +161,7 @@ class DefaultResultPrinter extends AbstractResultPrinter
 
     protected function restoreCursor()
     {
-        $this->write("\033[3F");
+        $this->write("\033[3A");
     }
 
     public function update()


### PR DESCRIPTION
iTerm does not understand the escape codes, the fix is changing `F` to `A`:

```php
        $this->write("\033[3A");
```

in `DefaultResultPrinter.php`