### PR TITLE
Compilation error using with() and single quotes

### DIFF
--- a/src/Concise/Mock/ClassCompiler.php
+++ b/src/Concise/Mock/ClassCompiler.php
@@ -204,7 +204,7 @@ EOF;
                 $defaultActionCode = $action->getActionCode();
             } else {
                 $args = addslashes(json_encode($rule['with']));
-                $args = str_replace('$', '\\$', $args);
+                $args = str_replace(array('$', "\\'"), array('\\$', "'"), $args);
                 $actionCode .= <<<EOF
     \$matcher = new \Concise\Mock\ArgumentMatcher();
     \$methodArguments = new \Concise\Services\MethodArguments();

--- a/tests/Concise/Mock/BuilderWithTest.php
+++ b/tests/Concise/Mock/BuilderWithTest.php
@@ -159,4 +159,16 @@ class BuilderWithTest extends AbstractBuilderTestCase
         $mock = $builder->expect('myWithMethodDefaults')->with('bar', 'foo', 'baz')->andReturn(null)->get();
         $mock->myWithMethodDefaults('bar');
     }
+
+    /**
+     * @group #248
+     * @dataProvider allBuilders
+     */
+    public function testWithIncludingSingleQuotes(MockBuilder $builder)
+    {
+        $mock = $builder->expect('myMethod')->with("foo'bar")
+            ->get();
+
+        $mock->myMethod("foo'bar");
+    }
 }


### PR DESCRIPTION
```php
        $select = $this->mock('\CDbCommand')
            ->disableConstructor()
            ->expect('join')->with('producttags', 'producttags.productid = products.productid')
            ->expect('andWhere')->with("lower(tagname) IN ('foo', bar)")
            ->stub(['getConnection' => DBManager::masterConnection()])
            ->get();
```

```
Argument 1 passed to Concise\Mock\ArgumentMatcher::match() must be of the type array, null given, called in /mnt/hgfs/git/kounta/vendor/elliotchance/concise/src/Concise/Mock/ClassCompiler.php(370) : eval()'d code on line 123 and defined
```

Changing to:

```php
            ->expect('andWhere')->with("lower(tagname) IN (foo, bar)")
```

Works as expected.