### PR TITLE
HasPropertyWithValue does not work for non stdClass

### DIFF
--- a/src/Concise/Assertion.php
+++ b/src/Concise/Assertion.php
@@ -8,8 +8,8 @@ use Concise\Services\ValueDescriptor;
 use Concise\Services\ValueRenderer;
 use Concise\Syntax\Lexer;
 use Concise\Syntax\Token\Attribute;
-use Concise\Validation\DataTypeChecker;
 use Concise\Validation\ArgumentChecker;
+use Concise\Validation\DataTypeChecker;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit_Framework_AssertionFailedError;
@@ -17,33 +17,33 @@ use PHPUnit_Framework_AssertionFailedError;
 class Assertion
 {
     /**
-	 * @var \Concise\Matcher\AbstractMatcher
-	 */
+     * @var \Concise\Matcher\AbstractMatcher
+     */
     protected $matcher;
 
     /**
-	 * @var string
-	 */
+     * @var string
+     */
     protected $assertionString;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $data = array();
 
     /**
-	 * @var \PHPUnit_Framework_TestCase
-	 */
+     * @var \PHPUnit_Framework_TestCase
+     */
     protected $testCase = null;
 
     /**
-	 * @var string
-	 */
+     * @var string
+     */
     protected $description = '';
 
     /**
-	 * @var string
-	 */
+     * @var string
+     */
     protected $originalSyntax = '';
 
     /**
@@ -52,13 +52,15 @@ class Assertion
     protected $failureMessage = '';
 
     /**
-	 * @param string                  $assertionString
-	 * @param Matcher\AbstractMatcher $matcher
-	 * @param array                   $data
-	 */
-    public function __construct($assertionString, Matcher\AbstractMatcher $matcher,
-        array $data = array())
-    {
+     * @param string                  $assertionString
+     * @param Matcher\AbstractMatcher $matcher
+     * @param array                   $data
+     */
+    public function __construct(
+        $assertionString,
+        Matcher\AbstractMatcher $matcher,
+        array $data = array()
+    ) {
         ArgumentChecker::check($assertionString, 'string');
 
         $this->assertionString = $assertionString;
@@ -67,8 +69,8 @@ class Assertion
     }
 
     /**
-	 * @param string $originalSyntax
-	 */
+     * @param string $originalSyntax
+     */
     public function setOriginalSyntax($originalSyntax)
     {
         ArgumentChecker::check($originalSyntax, 'string');
@@ -77,32 +79,32 @@ class Assertion
     }
 
     /**
-	 * @param \Concise\TestCase $testCase
-	 */
+     * @param \Concise\TestCase $testCase
+     */
     public function setTestCase(TestCase $testCase)
     {
         $this->testCase = $testCase;
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function getAssertion()
     {
         return $this->assertionString;
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getData()
     {
         return $this->data;
     }
 
     /**
-	 * @return \Concise\Matcher\AbstractMatcher
-	 */
+     * @return \Concise\Matcher\AbstractMatcher
+     */
     public function getMatcher()
     {
         return $this->matcher;
@@ -110,16 +112,20 @@ class Assertion
 
     /**
      * @param Attribute $arg
-     * @param integer $index
-     * @param $argument
+     * @param integer   $index
+     * @param           $argument
      * @throws Exception
      */
     protected function throwExceptionForInvalidArgument($arg, $index, $argument)
     {
         $renderer = new ValueRenderer();
         $acceptedTypes = implode(" or ", $arg->getAcceptedTypes());
-        $message = sprintf("Argument %d (%s) must be %s.", $index, $renderer->render($argument),
-            $acceptedTypes);
+        $message = sprintf(
+            "Argument %d (%s) must be %s.",
+            $index,
+            $renderer->render($argument),
+            $acceptedTypes
+        );
         throw new Exception($message);
     }
 
@@ -140,9 +146,16 @@ class Assertion
         $r = array();
         for ($i = 0; $i < $len; ++$i) {
             try {
-                $r[] = $checker->check($args[$i]->getAcceptedTypes(), $arguments[$i]);
+                $r[] = $checker->check(
+                    $args[$i]->getAcceptedTypes(),
+                    $arguments[$i]
+                );
             } catch (InvalidArgumentException $e) {
-                $this->throwExceptionForInvalidArgument($args[$i], $i + 1, $arguments[$i]);
+                $this->throwExceptionForInvalidArgument(
+                    $args[$i],
+                    $i + 1,
+                    $arguments[$i]
+                );
             }
         }
 
@@ -160,14 +173,15 @@ class Assertion
 
     /**
      * @param string $syntax
-     * @param array $args
+     * @param array  $args
      * @return string
      */
     protected function getFailureMessage($syntax, array $args)
     {
         $message = $this->failureMessage;
         if (!$message) {
-            $message = $this->getMatcher()->renderFailureMessage($syntax, $args);
+            $message =
+                $this->getMatcher()->renderFailureMessage($syntax, $args);
         }
 
         return $message;
@@ -181,7 +195,7 @@ class Assertion
         for ($i = 0; $i < $len; ++$i) {
             $arg = $arguments[$i];
             if ($arg instanceof Attribute) {
-                $args[$i] = $data[(string) $arg];
+                $args[$i] = $data[(string)$arg];
             } else {
                 $args[$i] = $arg;
             }
@@ -193,7 +207,7 @@ class Assertion
     }
 
     /**
-     * @param array $args
+     * @param array  $args
      * @param string $syntax
      * @return boolean
      */
@@ -202,7 +216,8 @@ class Assertion
         try {
             return $this->getMatcher()->match($this->originalSyntax, $args);
         } catch (DidNotMatchException $e) {
-            $message = $e->getMessage() ?: $this->getFailureMessage($syntax, $args);
+            $message =
+                $e->getMessage() ?: $this->getFailureMessage($syntax, $args);
             throw new PHPUnit_Framework_AssertionFailedError($message);
         }
     }
@@ -219,8 +234,9 @@ class Assertion
 
         $answer = $this->performMatch($result['syntax'], $args);
 
-        if (!$this->getMatcher() instanceof AbstractNestedMatcher && true !== $answer &&
-            null !== $answer) {
+        if (!$this->getMatcher() instanceof AbstractNestedMatcher &&
+            true !== $answer && null !== $answer
+        ) {
             $message = $this->getFailureMessage($result['syntax'], $args);
             throw new PHPUnit_Framework_AssertionFailedError($message);
         }
@@ -239,8 +255,8 @@ class Assertion
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function __toString()
     {
         $excludeKeys = array_keys(TestCase::getPHPUnitProperties());
@@ -251,7 +267,8 @@ class Assertion
         $r = "";
         foreach ($this->getData() as $k => $v) {
             if (!in_array($k, $excludeKeys)) {
-                $r .= "\n  $k (" . $descriptor->describe($v) . ") = " . $renderer->render($v);
+                $r .= "\n  $k (" . $descriptor->describe($v) . ") = " .
+                    $renderer->render($v);
             }
         }
 
@@ -263,16 +280,16 @@ class Assertion
     }
 
     /**
-	 * @param string $description
-	 */
+     * @param string $description
+     */
     public function setDescription($description)
     {
         $this->description = $description;
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function getDescription()
     {
         if ('' === $this->description) {

--- a/src/Concise/Console/Command.php
+++ b/src/Concise/Console/Command.php
@@ -2,12 +2,12 @@
 
 namespace Concise\Console;
 
-use Concise\Console\TestRunner\DefaultTestRunner;
-use Concise\Console\ResultPrinter\ResultPrinterProxy;
+use Concise\Console\ResultPrinter\CIResultPrinter;
 use Concise\Console\ResultPrinter\DefaultResultPrinter;
+use Concise\Console\ResultPrinter\ResultPrinterProxy;
+use Concise\Console\TestRunner\DefaultTestRunner;
 use Concise\Console\Theme\DefaultTheme;
 use Exception;
-use Concise\Console\ResultPrinter\CIResultPrinter;
 
 class Command extends \PHPUnit_TextUI_Command
 {
@@ -24,7 +24,9 @@ class Command extends \PHPUnit_TextUI_Command
     protected function createRunner()
     {
         $resultPrinter = $this->getResultPrinter();
-        if (array_key_exists('verbose', $this->arguments) && $this->arguments['verbose']) {
+        if (array_key_exists('verbose', $this->arguments) &&
+            $this->arguments['verbose']
+        ) {
             $resultPrinter->setVerbose(true);
         }
         $testRunner = new DefaultTestRunner();
@@ -52,7 +54,10 @@ class Command extends \PHPUnit_TextUI_Command
      */
     protected function findTheme()
     {
-        $candidates = array($this->colorScheme, "Concise\\Console\\Theme\\{$this->colorScheme}Theme");
+        $candidates = array(
+            $this->colorScheme,
+            "Concise\\Console\\Theme\\{$this->colorScheme}Theme"
+        );
         foreach ($candidates as $class) {
             $r = $this->getThemeForClass($class);
             if ($r) {

--- a/src/Concise/Console/ResultPrinter/AbstractResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/AbstractResultPrinter.php
@@ -2,12 +2,13 @@
 
 namespace Concise\Console\ResultPrinter;
 
-use Exception;
-use PHPUnit_Framework_TestSuite;
 use Concise\Console\TestRunner\TestResultDelegateInterface;
+use Exception;
 use PHPUnit_Framework_Test;
+use PHPUnit_Framework_TestSuite;
 
-abstract class AbstractResultPrinter implements TestResultDelegateInterface, StatisticsInterface
+abstract class AbstractResultPrinter
+    implements TestResultDelegateInterface, StatisticsInterface
 {
     /**
      * @var integer
@@ -59,8 +60,9 @@ abstract class AbstractResultPrinter implements TestResultDelegateInterface, Sta
      */
     public function getSuccessCount()
     {
-        return $this->getTestCount() - $this->getFailureCount() - $this->getErrorCount()
-            - $this->getSkippedCount() - $this->getIncompleteCount() - $this->getRiskyCount();
+        return $this->getTestCount() - $this->getFailureCount() -
+        $this->getErrorCount() - $this->getSkippedCount() -
+        $this->getIncompleteCount() - $this->getRiskyCount();
     }
 
     /**
@@ -127,8 +129,12 @@ abstract class AbstractResultPrinter implements TestResultDelegateInterface, Sta
         return $this->assertionCount;
     }
 
-    public function endTest($status, PHPUnit_Framework_Test $test, $time, Exception $e = null)
-    {
+    public function endTest(
+        $status,
+        PHPUnit_Framework_Test $test,
+        $time,
+        Exception $e = null
+    ) {
     }
 
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite)

--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -197,9 +197,9 @@ class DefaultResultPrinter extends AbstractResultPrinter
     }
 
     /**
-     * @param integer $status
+     * @param integer                $status
      * @param PHPUnit_Framework_Test $test
-     * @param Exception $e
+     * @param Exception              $e
      */
     protected function add($status, PHPUnit_Framework_Test $test, Exception $e)
     {

--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -2,15 +2,15 @@
 
 namespace Concise\Console\ResultPrinter;
 
+use Concise\Console\ResultPrinter\Utilities\ProgressCounter;
+use Concise\Console\ResultPrinter\Utilities\ProportionalProgressBar;
+use Concise\Console\ResultPrinter\Utilities\RenderIssue;
 use Concise\Console\Theme\DefaultTheme;
 use Concise\Services\TimeFormatter;
 use Exception;
-use PHPUnit_Runner_BaseTestRunner;
-use Concise\Console\ResultPrinter\Utilities\ProportionalProgressBar;
-use Concise\Console\ResultPrinter\Utilities\ProgressCounter;
-use Concise\Console\ResultPrinter\Utilities\RenderIssue;
 use PHPUnit_Framework_Test;
 use PHPUnit_Framework_TestSuite;
+use PHPUnit_Runner_BaseTestRunner;
 
 class DefaultResultPrinter extends AbstractResultPrinter
 {
@@ -62,7 +62,7 @@ class DefaultResultPrinter extends AbstractResultPrinter
     public function __construct(DefaultTheme $theme = null)
     {
         /** @noinspection SpellCheckingInspection */
-        $this->width = (int) exec('tput cols');
+        $this->width = (int)exec('tput cols');
         if (!$theme) {
             $theme = new DefaultTheme();
         }
@@ -77,9 +77,15 @@ class DefaultResultPrinter extends AbstractResultPrinter
         $this->update();
     }
 
-    public function endTest($status, PHPUnit_Framework_Test $test, $time, Exception $e = null)
-    {
-        if ($status !== PHPUnit_Runner_BaseTestRunner::STATUS_PASSED && $e instanceof Exception) {
+    public function endTest(
+        $status,
+        PHPUnit_Framework_Test $test,
+        $time,
+        Exception $e = null
+    ) {
+        if ($status !== PHPUnit_Runner_BaseTestRunner::STATUS_PASSED &&
+            $e instanceof Exception
+        ) {
             $this->add($status, $test, $e);
         }
         $this->update();
@@ -89,12 +95,17 @@ class DefaultResultPrinter extends AbstractResultPrinter
     {
         $progressBar = new ProportionalProgressBar();
 
-        return $progressBar->renderProportional($this->width, $this->getTotalTestCount(), array(
-            'green'   => $this->getSuccessCount(),
-            'yellow'  => $this->getIncompleteCount() + $this->getRiskyCount(),
-            'blue'    => $this->getSkippedCount(),
-            'red'     => $this->getFailureCount() + $this->getErrorCount(),
-        )) . "\n";
+        return $progressBar->renderProportional(
+            $this->width,
+            $this->getTotalTestCount(),
+            array(
+                'green' => $this->getSuccessCount(),
+                'yellow' => $this->getIncompleteCount() +
+                    $this->getRiskyCount(),
+                'blue' => $this->getSkippedCount(),
+                'red' => $this->getFailureCount() + $this->getErrorCount(),
+            )
+        ) . "\n";
     }
 
     protected function getSecondsElapsed()
@@ -122,7 +133,9 @@ class DefaultResultPrinter extends AbstractResultPrinter
         $remainingSeconds = $this->getRemainingSeconds();
         $this->remainingSecondsString = '';
         if ($this->getSecondsElapsed() >= 5 && $remainingSeconds >= 1) {
-            $this->remainingSecondsString = ' (' . $this->formatter->format($remainingSeconds, $short) . ' remaining)';
+            $this->remainingSecondsString =
+                ' (' . $this->formatter->format($remainingSeconds, $short) .
+                ' remaining)';
         }
 
         $this->lastUpdatedRemainingSecondsAt = time();
@@ -137,17 +150,25 @@ class DefaultResultPrinter extends AbstractResultPrinter
     {
         $assertionString = $this->getAssertionCount() . ' assertion' .
             ($this->getAssertionCount() == 1 ? '' : 's');
-        $time = ', ' . $this->formatter->format($this->getSecondsElapsed(), $short);
+        $time =
+            ', ' . $this->formatter->format($this->getSecondsElapsed(), $short);
         $remaining = $this->getRemainingTimeString($short);
         $counterString = $this->counter->render($this->getTestCount());
-        $pad = $this->width - strlen($assertionString) - strlen($counterString) - strlen($time) -
-            strlen($remaining);
+        $pad =
+            $this->width - strlen($assertionString) - strlen($counterString) -
+            strlen($time) - strlen($remaining);
 
         if ($pad < 0) {
             return '';
         }
-        return sprintf("%s%s%s%s%s\n", $assertionString, $time, $remaining, str_repeat(' ', $pad),
-            $counterString);
+        return sprintf(
+            "%s%s%s%s%s\n",
+            $assertionString,
+            $time,
+            $remaining,
+            str_repeat(' ', $pad),
+            $counterString
+        );
     }
 
     protected function getAssertionString()
@@ -169,7 +190,9 @@ class DefaultResultPrinter extends AbstractResultPrinter
         if ($this->hasUpdated) {
             $this->restoreCursor();
         }
-        $this->write($this->getAssertionString() . $this->drawProgressBar() . "\n");
+        $this->write(
+            $this->getAssertionString() . $this->drawProgressBar() . "\n"
+        );
         $this->hasUpdated = true;
     }
 

--- a/src/Concise/Console/ResultPrinter/ResultPrinterProxy.php
+++ b/src/Concise/Console/ResultPrinter/ResultPrinterProxy.php
@@ -5,10 +5,10 @@ namespace Concise\Console\ResultPrinter;
 use Exception;
 use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit_Framework_Test;
+use PHPUnit_Framework_TestFailure;
 use PHPUnit_Framework_TestResult;
 use PHPUnit_Framework_TestSuite;
 use PHPUnit_Runner_BaseTestRunner;
-use PHPUnit_Framework_TestFailure;
 use PHPUnit_TextUI_ResultPrinter;
 
 class ResultPrinterProxy extends PHPUnit_TextUI_ResultPrinter
@@ -45,34 +45,71 @@ class ResultPrinterProxy extends PHPUnit_TextUI_ResultPrinter
         return $this->resultPrinter;
     }
 
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
+    public function addFailure(
+        PHPUnit_Framework_Test $test,
+        PHPUnit_Framework_AssertionFailedError $e,
+        $time
+    ) {
         ++$this->getResultPrinter()->failureCount;
-        $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, $test, $time, $e);
+        $this->getResultPrinter()->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+            $test,
+            $time,
+            $e
+        );
     }
 
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         ++$this->getResultPrinter()->errorCount;
-        $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR, $test, $time, $e);
+        $this->getResultPrinter()->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR,
+            $test,
+            $time,
+            $e
+        );
     }
 
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
+    public function addIncompleteTest(
+        PHPUnit_Framework_Test $test,
+        Exception $e,
+        $time
+    ) {
         ++$this->getResultPrinter()->incompleteCount;
-        $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, $test, $time, $e);
+        $this->getResultPrinter()->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE,
+            $test,
+            $time,
+            $e
+        );
     }
 
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
+    public function addSkippedTest(
+        PHPUnit_Framework_Test $test,
+        Exception $e,
+        $time
+    ) {
         ++$this->getResultPrinter()->skippedCount;
-        $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, $test, $time, $e);
+        $this->getResultPrinter()->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED,
+            $test,
+            $time,
+            $e
+        );
     }
 
-    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
+    public function addRiskyTest(
+        PHPUnit_Framework_Test $test,
+        Exception $e,
+        $time
+    ) {
         ++$this->getResultPrinter()->riskyCount;
-        $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY, $test, $time, $e);
+        $this->getResultPrinter()->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY,
+            $test,
+            $time,
+            $e
+        );
     }
 
     protected function printHeader()
@@ -83,8 +120,10 @@ class ResultPrinterProxy extends PHPUnit_TextUI_ResultPrinter
     {
     }
 
-    protected function printDefect(PHPUnit_Framework_TestFailure $defect, $count)
-    {
+    protected function printDefect(
+        PHPUnit_Framework_TestFailure $defect,
+        $count
+    ) {
     }
 
     protected function printFooter(PHPUnit_Framework_TestResult $result)
@@ -104,13 +143,20 @@ class ResultPrinterProxy extends PHPUnit_TextUI_ResultPrinter
         ++$this->getResultPrinter()->testCount;
         if (is_subclass_of($test, "PHPUnit_Framework_TestCase")) {
             /** @var $test \PHPUnit_Framework_TestCase */
-            $this->getResultPrinter()->assertionCount += $test->getNumAssertions();
+            $this->getResultPrinter()->assertionCount +=
+                $test->getNumAssertions();
         } else {
             ++$this->getResultPrinter()->assertionCount;
         }
 
-        if ($this->totalSuccesses < $this->getResultPrinter()->getSuccessCount()) {
-            $this->getResultPrinter()->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $test, $time);
+        if ($this->totalSuccesses <
+            $this->getResultPrinter()->getSuccessCount()
+        ) {
+            $this->getResultPrinter()->endTest(
+                PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+                $test,
+                $time
+            );
         }
         $this->totalSuccesses = $this->getResultPrinter()->getSuccessCount();
     }

--- a/src/Concise/Console/ResultPrinter/Utilities/FilePathSimplifier.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/FilePathSimplifier.php
@@ -7,9 +7,9 @@ use Concise\Validation\ArgumentChecker;
 class FilePathSimplifier
 {
     /**
-	 * @param  string $filePath
-	 * @return string
-	 */
+     * @param  string $filePath
+     * @return string
+     */
     public function process($filePath)
     {
         ArgumentChecker::check($filePath, 'string');

--- a/src/Concise/Console/ResultPrinter/Utilities/ProgressBar.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/ProgressBar.php
@@ -9,18 +9,21 @@ class ProgressBar
 {
     /**
      * The sum of all the parts.
+     *
      * @var integer
      */
     protected $total;
 
     /**
      * The width (in column/characters of the progress bar).
+     *
      * @var integer
      */
     protected $size;
 
     /**
      * The individual [color => value] that make up the progress bar.
+     *
      * @var integer[]
      */
     protected $parts;
@@ -36,14 +39,14 @@ class ProgressBar
 
     protected function calculateTotal(array $parts)
     {
-        $this->total = (int) array_sum($parts);
+        $this->total = (int)array_sum($parts);
     }
 
     protected function colorSpaces($length, $colorName)
     {
         $c = new Color();
 
-        return (string) $c(str_repeat(' ', $length))->highlight($colorName);
+        return (string)$c(str_repeat(' ', $length))->highlight($colorName);
     }
 
     /**
@@ -55,7 +58,8 @@ class ProgressBar
         reset($this->parts);
         $fill = $this->size - substr_count($currentProgressBar, ' ');
         if ($fill < 0) {
-            $currentProgressBar = preg_replace('/\s\s/', ' ', $currentProgressBar, -$fill);
+            $currentProgressBar =
+                preg_replace('/\s\s/', ' ', $currentProgressBar, -$fill);
         }
 
         return $currentProgressBar;
@@ -63,8 +67,11 @@ class ProgressBar
 
     /**
      * Render the progress bar.
-     * @param  integer $size  The width (in column/characters of the progress bar).
-     * @param  array   $parts The individual [color => value] that make up the progress bar.
+     *
+     * @param  integer $size The width (in column/characters of the progress
+     *     bar).
+     * @param  array   $parts The individual [color => value] that make up the
+     *     progress bar.
      * @return string
      */
     public function render($size, array $parts)

--- a/src/Concise/Console/ResultPrinter/Utilities/ProgressCounter.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/ProgressCounter.php
@@ -2,13 +2,14 @@
 
 namespace Concise\Console\ResultPrinter\Utilities;
 
-use DomainException;
 use Concise\Validation\ArgumentChecker;
+use DomainException;
 
 class ProgressCounter
 {
     /**
      * Total value
+     *
      * @var integer
      */
     protected $total;
@@ -20,7 +21,7 @@ class ProgressCounter
 
     /**
      * @param integer $value
-     * @param string $name
+     * @param string  $name
      */
     protected function atLeastZero($value, $name)
     {
@@ -62,6 +63,10 @@ class ProgressCounter
      */
     public function getPercentage($value)
     {
-        return (0 === $this->total) ? 0 : (int) floor($value / $this->total * 100);
+        return (0 === $this->total)
+            ? 0
+            : (int)floor(
+                $value / $this->total * 100
+            );
     }
 }

--- a/src/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBar.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBar.php
@@ -9,7 +9,7 @@ class ProportionalProgressBar extends ProgressBar
     /**
      * @param integer $size
      * @param integer $total
-     * @param array $parts
+     * @param array   $parts
      * @return string
      */
     public function renderProportional($size, $total, array $parts)
@@ -25,7 +25,7 @@ class ProportionalProgressBar extends ProgressBar
             return str_repeat('_', $size);
         }
         $barSize = $size * $this->total / $total;
-        $bar = parent::render((int) $barSize, $parts);
+        $bar = parent::render((int)$barSize, $parts);
         $spaces = $size - substr_count($bar, ' ');
 
         return $bar . str_repeat('_', $spaces);

--- a/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
+++ b/src/Concise/Console/ResultPrinter/Utilities/RenderIssue.php
@@ -2,12 +2,12 @@
 
 namespace Concise\Console\ResultPrinter\Utilities;
 
-use Exception;
 use Colors\Color;
 use Concise\Console\Theme\DefaultTheme;
-use PHPUnit_Framework_Test;
-use PHPUnit_Framework_ExpectationFailedException;
 use Concise\Validation\ArgumentChecker;
+use Exception;
+use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit_Framework_Test;
 use PHPUnit_Framework_TestCase;
 
 class RenderIssue
@@ -65,13 +65,16 @@ class RenderIssue
     }
 
     /**
-     * @param integer $status
-     * @param integer $issueNumber
+     * @param integer                $status
+     * @param integer                $issueNumber
      * @param PHPUnit_Framework_Test $test
      * @return string
      */
-    protected function getHeading($status, $issueNumber, PHPUnit_Framework_Test $test)
-    {
+    protected function getHeading(
+        $status,
+        $issueNumber,
+        PHPUnit_Framework_Test $test
+    ) {
         $c = new Color();
         $color = $this->colors[$status];
 
@@ -83,23 +86,33 @@ class RenderIssue
     }
 
     /**
-     * @param integer $status
-     * @param integer $issueNumber
+     * @param integer                $status
+     * @param integer                $issueNumber
      * @param PHPUnit_Framework_Test $test
-     * @param Exception $e
+     * @param Exception              $e
      * @return string
      */
-    public function render($status, $issueNumber, PHPUnit_Framework_Test $test, Exception $e)
-    {
+    public function render(
+        $status,
+        $issueNumber,
+        PHPUnit_Framework_Test $test,
+        Exception $e
+    ) {
         ArgumentChecker::check($issueNumber, 'integer');
 
         $c = new Color();
         $top = $this->getHeading($status, $issueNumber, $test);
         $message = $e->getMessage() . "\n";
         $message .= $this->getPHPUnitDiff($e);
-        $message .= "\n" . $this->prefixLines("\033[90m", $this->traceSimplifier->render($e->getTrace())) . "\033[0m";
+        $message .= "\n" . $this->prefixLines(
+                "\033[90m",
+                $this->traceSimplifier->render($e->getTrace())
+            ) . "\033[0m";
         $pad = str_repeat(' ', strlen($issueNumber));
 
-        return $top . $this->prefixLines($c("  ")->highlight($this->colors[$status]) . $pad, rtrim($message));
+        return $top . $this->prefixLines(
+            $c("  ")->highlight($this->colors[$status]) . $pad,
+            rtrim($message)
+        );
     }
 }

--- a/src/Concise/Console/TestColors.php
+++ b/src/Concise/Console/TestColors.php
@@ -13,12 +13,26 @@ class TestColors
         $lines = array(
             $renderer->render('? is null', array(null)),
             $renderer->render('? does not equal ?', array(true, false)),
-            $renderer->render('? has key ? with value ?', array(array("foo" => 123), 'foo', 123)),
-            $renderer->render('? is instance of ?', array(new DateTime(), 'DateTime')),
+            $renderer->render(
+                '? has key ? with value ?',
+                array(array("foo" => 123), 'foo', 123)
+            ),
+            $renderer->render(
+                '? is instance of ?',
+                array(new DateTime(), 'DateTime')
+            ),
             $renderer->render('? equals ? within ?', array(1.57, 1.5, 0.5)),
-            $renderer->render('? is instance of ?', array(function () {}, 'Closure')),
+            $renderer->render(
+                '? is instance of ?',
+                array(
+                    function () {
+                    },
+                    'Closure'
+                )
+            ),
         );
 
-        return "Some assertion examples:\n\n" . implode("\n\n", $lines) . "\n\n";
+        return "Some assertion examples:\n\n" . implode("\n\n", $lines) .
+        "\n\n";
     }
 }

--- a/src/Concise/Console/TestRunner/TestResultDelegateInterface.php
+++ b/src/Concise/Console/TestRunner/TestResultDelegateInterface.php
@@ -9,10 +9,10 @@ use PHPUnit_Framework_TestSuite;
 interface TestResultDelegateInterface
 {
     /**
-     * @param int $status A status constant from PHPUnit_Runner_BaseTestRunner
+     * @param int                    $status A status constant from PHPUnit_Runner_BaseTestRunner
      * @param PHPUnit_Framework_Test $test The test that just finished.
-     * @param float $time The number of seconds the test took to execute.
-     * @param Exception $e The error (applies to all statuses except
+     * @param float                  $time The number of seconds the test took to execute.
+     * @param Exception              $e The error (applies to all statuses except
      *     STATUS_PASSED)
      * @return void
      */

--- a/src/Concise/Console/TestRunner/TestResultDelegateInterface.php
+++ b/src/Concise/Console/TestRunner/TestResultDelegateInterface.php
@@ -3,19 +3,25 @@
 namespace Concise\Console\TestRunner;
 
 use Exception;
-use PHPUnit_Framework_TestSuite;
 use PHPUnit_Framework_Test;
+use PHPUnit_Framework_TestSuite;
 
 interface TestResultDelegateInterface
 {
     /**
-     * @param int                    $status A status constant from PHPUnit_Runner_BaseTestRunner
-     * @param PHPUnit_Framework_Test $test   The test that just finished.
-     * @param float                  $time   The number of seconds the test took to execute.
-     * @param Exception              $e      The error (applies to all statuses except STATUS_PASSED)
+     * @param int $status A status constant from PHPUnit_Runner_BaseTestRunner
+     * @param PHPUnit_Framework_Test $test The test that just finished.
+     * @param float $time The number of seconds the test took to execute.
+     * @param Exception $e The error (applies to all statuses except
+     *     STATUS_PASSED)
      * @return void
      */
-    public function endTest($status, PHPUnit_Framework_Test $test, $time, Exception $e = null);
+    public function endTest(
+        $status,
+        PHPUnit_Framework_Test $test,
+        $time,
+        Exception $e = null
+    );
 
     /**
      * @param PHPUnit_Framework_TestSuite $suite
@@ -31,6 +37,7 @@ interface TestResultDelegateInterface
 
     /**
      * Is invoked once at the very end.
+     *
      * @return void
      */
     public function end();

--- a/src/Concise/Console/Theme/AbstractTheme.php
+++ b/src/Concise/Console/Theme/AbstractTheme.php
@@ -12,18 +12,12 @@ abstract class AbstractTheme implements ThemeInterface
     public function getTheme()
     {
         return array(
-            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => $this->getStatusPassedColor(
-            ),
-            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => $this->getStatusFailureColor(
-            ),
-            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => $this->getStatusErrorColor(
-            ),
-            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => $this->getStatusSkippedColor(
-            ),
-            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => $this->getStatusIncompleteColor(
-            ),
-            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => $this->getStatusRiskyColor(
-            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => $this->getStatusPassedColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => $this->getStatusFailureColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => $this->getStatusErrorColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => $this->getStatusSkippedColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => $this->getStatusIncompleteColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => $this->getStatusRiskyColor(),
             'value.integer' => $this->getValueIntegerColor(),
             'value.float' => $this->getValueFloatColor(),
             'value.string' => $this->getValueStringColor(),

--- a/src/Concise/Console/Theme/AbstractTheme.php
+++ b/src/Concise/Console/Theme/AbstractTheme.php
@@ -12,18 +12,24 @@ abstract class AbstractTheme implements ThemeInterface
     public function getTheme()
     {
         return array(
-            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED     => $this->getStatusPassedColor(),
-            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE    => $this->getStatusFailureColor(),
-            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR      => $this->getStatusErrorColor(),
-            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED    => $this->getStatusSkippedColor(),
-            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => $this->getStatusIncompleteColor(),
-            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY      => $this->getStatusRiskyColor(),
-            'value.integer'                                  => $this->getValueIntegerColor(),
-            'value.float'                                    => $this->getValueFloatColor(),
-            'value.string'                                   => $this->getValueStringColor(),
-            'value.closure'                                  => $this->getValueClosureColor(),
-            'value.null'                                     => $this->getValueNullColor(),
-            'value.boolean'                                  => $this->getValueBooleanColor(),
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => $this->getStatusPassedColor(
+            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => $this->getStatusFailureColor(
+            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => $this->getStatusErrorColor(
+            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => $this->getStatusSkippedColor(
+            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => $this->getStatusIncompleteColor(
+            ),
+            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => $this->getStatusRiskyColor(
+            ),
+            'value.integer' => $this->getValueIntegerColor(),
+            'value.float' => $this->getValueFloatColor(),
+            'value.string' => $this->getValueStringColor(),
+            'value.closure' => $this->getValueClosureColor(),
+            'value.null' => $this->getValueNullColor(),
+            'value.boolean' => $this->getValueBooleanColor(),
         );
     }
 

--- a/src/Concise/Keywords.php
+++ b/src/Concise/Keywords.php
@@ -5,7 +5,7 @@ namespace Concise;
 class Keywords
 {
     public static function load()
-    {    
+    {
     }
 }
 

--- a/src/Concise/Matcher/AbstractDateComparison.php
+++ b/src/Concise/Matcher/AbstractDateComparison.php
@@ -17,7 +17,7 @@ abstract class AbstractDateComparison extends AbstractNestedMatcher
     }
 
     /**
-     * @param array $data
+     * @param array   $data
      * @param integer $sign
      * @throws DidNotMatchException
      * @return

--- a/src/Concise/Matcher/AbstractMatcher.php
+++ b/src/Concise/Matcher/AbstractMatcher.php
@@ -2,25 +2,25 @@
 
 namespace Concise\Matcher;
 
-use \Concise\Services\SyntaxRenderer;
+use Concise\Services\SyntaxRenderer;
 
 abstract class AbstractMatcher
 {
     /**
      * @param string $syntax
-     * @param array $data
+     * @param array  $data
      * @return bool
      */
     abstract public function match($syntax, array $data = array());
 
     /**
-	 * @return array Syntaxes this matcher can understand.
-	 */
+     * @return array Syntaxes this matcher can understand.
+     */
     abstract public function supportedSyntaxes();
 
     /**
      * @param string $syntax
-     * @param array $data
+     * @param array  $data
      * @return string
      */
     public function renderFailureMessage($syntax, array $data = array())
@@ -31,7 +31,7 @@ abstract class AbstractMatcher
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     abstract public function getTags();
 }

--- a/src/Concise/Matcher/ContainsStringIgnoringCase.php
+++ b/src/Concise/Matcher/ContainsStringIgnoringCase.php
@@ -13,7 +13,10 @@ class ContainsStringIgnoringCase extends ContainsString
 
     public function match($syntax, array $data = array())
     {
-        return parent::match(null, array(strtolower($data[0]), strtolower($data[1])));
+        return parent::match(
+            null,
+            array(strtolower($data[0]), strtolower($data[1]))
+        );
     }
 
     public function getTags()

--- a/src/Concise/Matcher/DoesNotContainStringIgnoringCase.php
+++ b/src/Concise/Matcher/DoesNotContainStringIgnoringCase.php
@@ -13,7 +13,10 @@ class DoesNotContainStringIgnoringCase extends DoesNotContainString
 
     public function match($syntax, array $data = array())
     {
-        return parent::match(null, array(strtolower($data[0]), strtolower($data[1])));
+        return parent::match(
+            null,
+            array(strtolower($data[0]), strtolower($data[1]))
+        );
     }
 
     public function getTags()

--- a/src/Concise/Matcher/DoesNotHaveItem.php
+++ b/src/Concise/Matcher/DoesNotHaveItem.php
@@ -19,7 +19,10 @@ class DoesNotHaveItem extends HasItem
     public function match($syntax, array $data = array())
     {
         if ($syntax === self::SPLIT_SYNTAX) {
-            return !parent::match(null, array($data[0], array($data[1] => $data[2])));
+            return !parent::match(
+                null,
+                array($data[0], array($data[1] => $data[2]))
+            );
         }
 
         return !parent::match(null, $data);

--- a/src/Concise/Matcher/DoesNotHaveProperty.php
+++ b/src/Concise/Matcher/DoesNotHaveProperty.php
@@ -13,7 +13,7 @@ class DoesNotHaveProperty extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        return !array_key_exists($data[1], (array) $data[0]);
+        return !array_key_exists($data[1], (array)$data[0]);
     }
 
     public function getTags()

--- a/src/Concise/Matcher/DoesNotThrow.php
+++ b/src/Concise/Matcher/DoesNotThrow.php
@@ -20,7 +20,9 @@ class DoesNotThrow extends Throws
         } catch (\Exception $exception) {
             if ($this->isKindOfClass($exception, $data[1])) {
                 $exceptionClass = get_class($exception);
-                throw new DidNotMatchException("Expected {$data[1]} not to be thrown, but $exceptionClass was thrown.");
+                throw new DidNotMatchException(
+                    "Expected {$data[1]} not to be thrown, but $exceptionClass was thrown."
+                );
             }
         }
 

--- a/src/Concise/Matcher/DoesNotThrowException.php
+++ b/src/Concise/Matcher/DoesNotThrowException.php
@@ -18,7 +18,9 @@ class DoesNotThrowException extends AbstractMatcher
 
             return true;
         } catch (\Exception $exception) {
-            throw new DidNotMatchException("Expected exception not to be thrown.");
+            throw new DidNotMatchException(
+                "Expected exception not to be thrown."
+            );
         }
     }
 

--- a/src/Concise/Matcher/HasItem.php
+++ b/src/Concise/Matcher/HasItem.php
@@ -19,7 +19,10 @@ class HasItem extends AbstractMatcher
     public function match($syntax, array $data = array())
     {
         if ($syntax === self::SPLIT_SYNTAX) {
-            return $this->match(null, array($data[0], array($data[1] => $data[2])));
+            return $this->match(
+                null,
+                array($data[0], array($data[1] => $data[2]))
+            );
         }
         foreach ($data[0] as $key => $value) {
             if (array($key => $value) == $data[1]) {

--- a/src/Concise/Matcher/HasItems.php
+++ b/src/Concise/Matcher/HasItems.php
@@ -19,7 +19,11 @@ class HasItems extends HasItem
             return true;
         }
         foreach ($data[1] as $key => $value) {
-            if (!parent::match($data[0], array($data[0], array($key => $value)))) {
+            if (!parent::match(
+                $data[0],
+                array($data[0], array($key => $value))
+            )
+            ) {
                 return false;
             }
         }

--- a/src/Concise/Matcher/HasProperty.php
+++ b/src/Concise/Matcher/HasProperty.php
@@ -13,7 +13,7 @@ class HasProperty extends AbstractNestedMatcher
 
     public function match($syntax, array $data = array())
     {
-        if (!array_key_exists($data[1], (array) $data[0])) {
+        if (!array_key_exists($data[1], (array)$data[0])) {
             throw new DidNotMatchException();
         }
 

--- a/src/Concise/Matcher/HasPropertyWithExactValue.php
+++ b/src/Concise/Matcher/HasPropertyWithExactValue.php
@@ -13,7 +13,11 @@ class HasPropertyWithExactValue extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        return array_key_exists($data[1], (array) $data[0]) && ($data[0]->{$data[1]} === $data[2]);
+        if (method_exists($data[0], '__get') && $data[0]->{$data[1]}) {
+            return ($data[0]->{$data[1]} == $data[2]);
+        }
+        return array_key_exists($data[1], (array)$data[0]) &&
+        ($data[0]->{$data[1]} === $data[2]);
     }
 
     public function getTags()

--- a/src/Concise/Matcher/HasPropertyWithValue.php
+++ b/src/Concise/Matcher/HasPropertyWithValue.php
@@ -16,8 +16,10 @@ class HasPropertyWithValue extends AbstractMatcher
         if (method_exists($data[0], '__get') && $data[0]->{$data[1]}) {
             return ($data[0]->{$data[1]} == $data[2]);
         }
-        return array_key_exists($data[1],
-            (array)$data[0]) && ($data[0]->{$data[1]} == $data[2]);
+        return array_key_exists(
+            $data[1],
+            (array)$data[0]
+        ) && ($data[0]->{$data[1]} == $data[2]);
     }
 
     public function getTags()

--- a/src/Concise/Matcher/HasPropertyWithValue.php
+++ b/src/Concise/Matcher/HasPropertyWithValue.php
@@ -14,7 +14,7 @@ class HasPropertyWithValue extends AbstractMatcher
     public function match($syntax, array $data = array())
     {
         if (method_exists($data[0], '__get') && $data[0]->{$data[1]}) {
-            return true;
+            return ($data[0]->{$data[1]} == $data[2]);
         }
         return array_key_exists($data[1],
             (array)$data[0]) && ($data[0]->{$data[1]} == $data[2]);

--- a/src/Concise/Matcher/HasPropertyWithValue.php
+++ b/src/Concise/Matcher/HasPropertyWithValue.php
@@ -13,7 +13,11 @@ class HasPropertyWithValue extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        return array_key_exists($data[1], (array) $data[0]) && ($data[0]->{$data[1]} == $data[2]);
+        if (method_exists($data[0], '__get') && $data[0]->{$data[1]}) {
+            return true;
+        }
+        return array_key_exists($data[1],
+            (array)$data[0]) && ($data[0]->{$data[1]} == $data[2]);
     }
 
     public function getTags()

--- a/src/Concise/Matcher/IsInstanceOf.php
+++ b/src/Concise/Matcher/IsInstanceOf.php
@@ -22,7 +22,9 @@ class IsInstanceOf extends AbstractMatcher
         if (is_string($data[0])) {
             return true;
         }
-        return (get_class($data[0]) === $data[1]) || is_subclass_of($data[0], $data[1]) || array_key_exists($data[1], $interfaces);
+        return (get_class($data[0]) === $data[1]) ||
+        is_subclass_of($data[0], $data[1]) ||
+        array_key_exists($data[1], $interfaces);
     }
 
     public function getTags()

--- a/src/Concise/Matcher/IsTruthy.php
+++ b/src/Concise/Matcher/IsTruthy.php
@@ -13,7 +13,7 @@ class IsTruthy extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        return (bool) $data[0];
+        return (bool)$data[0];
     }
 
     public function getTags()

--- a/src/Concise/Matcher/StringEndsWith.php
+++ b/src/Concise/Matcher/StringEndsWith.php
@@ -13,7 +13,8 @@ class StringEndsWith extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        return ((substr($data[0], strlen($data[0]) - strlen($data[1])) === $data[1]));
+        return ((substr($data[0], strlen($data[0]) - strlen($data[1])) ===
+            $data[1]));
     }
 
     public function getTags()

--- a/src/Concise/Matcher/StringEqualsFile.php
+++ b/src/Concise/Matcher/StringEqualsFile.php
@@ -13,10 +13,10 @@ class StringEqualsFile extends AbstractMatcher
 
     public function match($syntax, array $data = array())
     {
-        if(!file_exists($data[1])) {
+        if (!file_exists($data[1])) {
             throw new DidNotMatchException("File '{$data[1]}' does not exist.");
         }
-        
+
         return $data[0] == file_get_contents($data[1]);
     }
 

--- a/src/Concise/Matcher/Throws.php
+++ b/src/Concise/Matcher/Throws.php
@@ -13,7 +13,8 @@ class Throws extends AbstractMatcher
 
     protected function isKindOfClass(\Exception $exception, $expectedClass)
     {
-        return (get_class($exception) === $expectedClass) || is_subclass_of($exception, $expectedClass);
+        return (get_class($exception) === $expectedClass) ||
+        is_subclass_of($exception, $expectedClass);
     }
 
     public function match($syntax, array $data = array())
@@ -25,9 +26,13 @@ class Throws extends AbstractMatcher
                 return true;
             }
             $exceptionClass = get_class($exception);
-            throw new DidNotMatchException("Expected {$data[1]} to be thrown, but $exceptionClass was thrown.");
+            throw new DidNotMatchException(
+                "Expected {$data[1]} to be thrown, but $exceptionClass was thrown."
+            );
         }
-        throw new DidNotMatchException("Expected {$data[1]} to be thrown, but nothing was thrown.");
+        throw new DidNotMatchException(
+            "Expected {$data[1]} to be thrown, but nothing was thrown."
+        );
     }
 
     public function getTags()

--- a/src/Concise/Matcher/ThrowsAnythingExcept.php
+++ b/src/Concise/Matcher/ThrowsAnythingExcept.php
@@ -18,7 +18,9 @@ class ThrowsAnythingExcept extends AbstractMatcher
         } catch (\Exception $exception) {
             $exceptionClass = get_class($exception);
             if ($exceptionClass === $data[1]) {
-                throw new DidNotMatchException("Expected any exception except {$data[1]} to be thrown, but $exceptionClass was thrown.");
+                throw new DidNotMatchException(
+                    "Expected any exception except {$data[1]} to be thrown, but $exceptionClass was thrown."
+                );
             }
 
             return false;

--- a/src/Concise/Matcher/ThrowsExactly.php
+++ b/src/Concise/Matcher/ThrowsExactly.php
@@ -18,12 +18,16 @@ class ThrowsExactly extends AbstractMatcher
         } catch (\Exception $exception) {
             $exceptionClass = get_class($exception);
             if ($exceptionClass !== $data[1]) {
-                throw new DidNotMatchException("Expected exactly {$data[1]} to be thrown, but $exceptionClass was thrown.");
+                throw new DidNotMatchException(
+                    "Expected exactly {$data[1]} to be thrown, but $exceptionClass was thrown."
+                );
             }
 
             return true;
         }
-        throw new DidNotMatchException("Expected exactly {$data[1]} to be thrown, but nothing was thrown.");
+        throw new DidNotMatchException(
+            "Expected exactly {$data[1]} to be thrown, but nothing was thrown."
+        );
     }
 
     public function getTags()

--- a/src/Concise/Mock/Action/AbstractAction.php
+++ b/src/Concise/Mock/Action/AbstractAction.php
@@ -5,7 +5,8 @@ namespace Concise\Mock\Action;
 abstract class AbstractAction
 {
     /**
-	 * @return string PHP code to be injected into the mocked method when building.
-	 */
+     * @return string PHP code to be injected into the mocked method when
+     *     building.
+     */
     abstract public function getActionCode();
 }

--- a/src/Concise/Mock/Action/AbstractCachingAction.php
+++ b/src/Concise/Mock/Action/AbstractCachingAction.php
@@ -10,7 +10,9 @@ class AbstractCachingAction extends AbstractAction
     public static $cache = array();
 
     /**
-     * Each time a ReturnValueAction is instantiated it will generate a new cache key.
+     * Each time a ReturnValueAction is instantiated it will generate a new
+     * cache key.
+     *
      * @var string
      */
     protected $cacheKey;

--- a/src/Concise/Mock/Action/DoAction.php
+++ b/src/Concise/Mock/Action/DoAction.php
@@ -17,6 +17,7 @@ class DoAction extends AbstractCachingAction
      */
     public function getActionCode()
     {
-        return parent::getActionCode() . "return \$v(new \Concise\Mock\Invocation(\Concise\Mock\Action\AbstractCachingAction::\$cache['{$this->cacheKey}i']++, func_get_args()));";
+        return parent::getActionCode() .
+        "return \$v(new \Concise\Mock\Invocation(\Concise\Mock\Action\AbstractCachingAction::\$cache['{$this->cacheKey}i']++, func_get_args()));";
     }
 }

--- a/src/Concise/Mock/Action/ReturnCallbackAction.php
+++ b/src/Concise/Mock/Action/ReturnCallbackAction.php
@@ -7,8 +7,8 @@ use Closure;
 class ReturnCallbackAction extends AbstractCachingAction
 {
     /**
-	 * @param Closure $callback
-	 */
+     * @param Closure $callback
+     */
     public function __construct(Closure $callback)
     {
         parent::__construct($callback);
@@ -20,6 +20,7 @@ class ReturnCallbackAction extends AbstractCachingAction
      */
     public function getActionCode()
     {
-        return parent::getActionCode() . "return \$v(new \Concise\Mock\Invocation(\Concise\Mock\Action\AbstractCachingAction::\$cache['{$this->cacheKey}i']++, func_get_args()));";
+        return parent::getActionCode() .
+        "return \$v(new \Concise\Mock\Invocation(\Concise\Mock\Action\AbstractCachingAction::\$cache['{$this->cacheKey}i']++, func_get_args()));";
     }
 }

--- a/src/Concise/Mock/Action/ReturnPropertyAction.php
+++ b/src/Concise/Mock/Action/ReturnPropertyAction.php
@@ -22,8 +22,7 @@ class ReturnPropertyAction extends AbstractAction
      */
     public function getActionCode()
     {
-        return
-"
+        return "
 if (property_exists(\$this, \"{$this->property}\")) {
 	return \$this->{$this->property};
 }

--- a/src/Concise/Mock/Action/ReturnSelfAction.php
+++ b/src/Concise/Mock/Action/ReturnSelfAction.php
@@ -5,8 +5,8 @@ namespace Concise\Mock\Action;
 class ReturnSelfAction extends AbstractAction
 {
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function getActionCode()
     {
         return 'return $this;';

--- a/src/Concise/Mock/Action/ReturnValueAction.php
+++ b/src/Concise/Mock/Action/ReturnValueAction.php
@@ -5,8 +5,8 @@ namespace Concise\Mock\Action;
 class ReturnValueAction extends AbstractCachingAction
 {
     /**
-	 * @param array $values
-	 */
+     * @param array $values
+     */
     public function __construct(array $values)
     {
         parent::__construct($values);

--- a/src/Concise/Mock/ClassCompiler.php
+++ b/src/Concise/Mock/ClassCompiler.php
@@ -169,11 +169,9 @@ class ClassCompiler
     protected function makeMethodThrowException(\ReflectionMethod $method)
     {
         $prototype = $this->getPublicPrototype($method->getName());
-        $message = "{$method->getName(
-        )}() does not have an associated action - consider a niceMock()?";
+        $message = "{$method->getName()}() does not have an associated action - consider a niceMock()?";
         if ($method->isAbstract()) {
-            $message = "{$method->getName(
-            )}() is abstract and has no associated action.";
+            $message = "{$method->getName()}() is abstract and has no associated action.";
         }
         $this->methods[$method->getName()] = <<<EOF
 $prototype {

--- a/src/Concise/Mock/InvocationInterface.php
+++ b/src/Concise/Mock/InvocationInterface.php
@@ -5,14 +5,17 @@ namespace Concise\Mock;
 interface InvocationInterface
 {
     /**
-     * Get the index of the invocation (how many times it has been called up until now) starting at
+     * Get the index of the invocation (how many times it has been called up
+     * until now) starting at
      * 1.
+     *
      * @return int
      */
     public function getInvokeCount();
 
     /**
      * Get the original arguments passed with the invocation.
+     *
      * @return array
      */
     public function getArguments();

--- a/src/Concise/Mock/MockBuilder.php
+++ b/src/Concise/Mock/MockBuilder.php
@@ -129,9 +129,9 @@ class MockBuilder
     }
 
     /**
-     * @param array $methods
+     * @param array                 $methods
      * @param Action\AbstractAction $action
-     * @param integer $times
+     * @param integer               $times
      */
     protected function addRule(
         array $methods,

--- a/src/Concise/Mock/MockBuilder.php
+++ b/src/Concise/Mock/MockBuilder.php
@@ -2,83 +2,91 @@
 
 namespace Concise\Mock;
 
+use Closure;
 use Concise\Services\MethodArguments;
-use Concise\TestCase;
 use Concise\Services\NumberToTimesConverter;
 use Concise\Services\ValueRenderer;
-use InvalidArgumentException;
-use Exception;
-use ReflectionClass;
-use Closure;
+use Concise\TestCase;
 use Concise\Validation\ArgumentChecker;
+use Exception;
+use InvalidArgumentException;
+use ReflectionClass;
 
 class MockBuilder
 {
     /**
-	 * @var TestCase
-	 */
+     * @var TestCase
+     */
     protected $testCase;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $rules = array();
 
     /**
-	 * @var bool
-	 */
+     * @var bool
+     */
     protected $niceMock;
 
     /**
-	 * The names of the methods to be mocked.
-	 * @var array
-	 */
+     * The names of the methods to be mocked.
+     *
+     * @var array
+     */
     protected $mockedMethods = array();
 
     /**
-	 * The original fully-qualified class name to create the mock from.
-	 * @var string
-	 */
+     * The original fully-qualified class name to create the mock from.
+     *
+     * @var string
+     */
     protected $className;
 
     /**
-	 * Used internally as the active mocked method when using chained methods to builds the rules
-     * for this method.
-	 * @var array
-	 */
+     * Used internally as the active mocked method when using chained methods
+     * to builds the rules for this method.
+     *
+     * @var array
+     */
     protected $currentRules = array();
 
     /**
-	 * The arguments associated with this rule.
-	 * @var array|null
-	 */
+     * The arguments associated with this rule.
+     *
+     * @var array|null
+     */
     protected $currentWith = null;
 
     /**
-	 * Constructor arguments.
-	 * @var array
-	 */
+     * Constructor arguments.
+     *
+     * @var array
+     */
     protected $constructorArgs;
 
     /**
-	 * @var boolean
-	 */
+     * @var boolean
+     */
     protected $disableConstructor = false;
 
     /**
      * A list of methods that should be exposed as public.
+     *
      * @var array
      */
     protected $expose = array();
 
     /**
-	 * If the current rule is expect()
-	 * @var boolean
-	 */
+     * If the current rule is expect()
+     *
+     * @var boolean
+     */
     protected $isExpecting = false;
 
     /**
      * You may set a customer class name for this mock.
+     *
      * @var string
      */
     protected $customClassName = '';
@@ -95,20 +103,25 @@ class MockBuilder
 
     /**
      * @param TestCase $testCase
-     * @param string $className
-     * @param bool $niceMock
-     * @param array $constructorArgs
+     * @param string   $className
+     * @param bool     $niceMock
+     * @param array    $constructorArgs
      * @throws \Exception
      */
-    public function __construct(TestCase $testCase, $className, $niceMock,
-        array $constructorArgs = array())
-    {
+    public function __construct(
+        TestCase $testCase,
+        $className,
+        $niceMock,
+        array $constructorArgs = array()
+    ) {
         ArgumentChecker::check($className, 'string', 2);
-        ArgumentChecker::check($niceMock,  'bool', 3);
+        ArgumentChecker::check($niceMock, 'bool', 3);
 
         $this->testCase = $testCase;
         if (!class_exists($className) && !interface_exists($className)) {
-            throw new Exception("Class or interface '$className' does not exist.");
+            throw new Exception(
+                "Class or interface '$className' does not exist."
+            );
         }
         $this->className = $className;
         $this->niceMock = $niceMock;
@@ -116,12 +129,15 @@ class MockBuilder
     }
 
     /**
-	 * @param array                 $methods
-	 * @param Action\AbstractAction $action
-	 * @param integer               $times
-	 */
-    protected function addRule(array $methods, Action\AbstractAction $action, $times = -1)
-    {
+     * @param array $methods
+     * @param Action\AbstractAction $action
+     * @param integer $times
+     */
+    protected function addRule(
+        array $methods,
+        Action\AbstractAction $action,
+        $times = -1
+    ) {
         $this->currentRules = $methods;
         foreach ($methods as $method) {
             $this->mockedMethods[] = $method;
@@ -146,13 +162,21 @@ class MockBuilder
         $this->reset();
         if (is_array($arg)) {
             if (count($arg) === 0) {
-                throw new Exception("stub() called with array must have at least 1 element.");
+                throw new Exception(
+                    "stub() called with array must have at least 1 element."
+                );
             }
             foreach ($arg as $method => $value) {
-                $this->addRule(array($method), new Action\ReturnValueAction(array($value)));
+                $this->addRule(
+                    array($method),
+                    new Action\ReturnValueAction(array($value))
+                );
             }
         } else {
-            $this->addRule(func_get_args(), new Action\ReturnValueAction(array(null)));
+            $this->addRule(
+                func_get_args(),
+                new Action\ReturnValueAction(array(null))
+            );
         }
 
         return $this;
@@ -176,13 +200,18 @@ class MockBuilder
     }
 
     /**
-	 * Compiler the mock into a usable instance.
-	 * @return object
-	 */
+     * Compiler the mock into a usable instance.
+     *
+     * @return object
+     */
     public function get()
     {
-        $compiler = new ClassCompiler($this->className, $this->niceMock, $this->constructorArgs,
-            $this->disableConstructor);
+        $compiler = new ClassCompiler(
+            $this->className,
+            $this->niceMock,
+            $this->constructorArgs,
+            $this->disableConstructor
+        );
         if ($this->customClassName) {
             $compiler->setCustomClassName($this->customClassName);
         }
@@ -216,7 +245,9 @@ class MockBuilder
     protected function hasAction($rule)
     {
         $action = $this->rules[$rule][$this->getWithKey()]['action'];
-        if ($action instanceof Action\ReturnValueAction && is_null(current($action->getValue()))) {
+        if ($action instanceof Action\ReturnValueAction &&
+            is_null(current($action->getValue()))
+        ) {
             return false;
         }
 
@@ -232,11 +263,14 @@ class MockBuilder
     {
         foreach ($this->currentRules as $rule) {
             if ($this->methodIsNeverExpected($rule)) {
-                $message = "You cannot assign an action to '{$rule}()' when it is never expected.";
+                $message =
+                    "You cannot assign an action to '{$rule}()' when it is never expected.";
                 throw new Exception($message);
             }
             if ($this->hasAction($rule)) {
-                throw new Exception("{$rule}() has more than one action attached.");
+                throw new Exception(
+                    "{$rule}() has more than one action attached."
+                );
             }
             $this->rules[$rule][$this->getWithKey()]['action'] = $action;
         }
@@ -263,34 +297,38 @@ class MockBuilder
     }
 
     /**
-	 * @param \Exception $exception
-	 * @return MockBuilder
-	 */
+     * @param \Exception $exception
+     * @return MockBuilder
+     */
     public function andThrow(Exception $exception)
     {
         return $this->setAction(new Action\ThrowAction($exception));
     }
 
     /**
-	 * Expect the method to called called exactly once.
-	 * @return MockBuilder
-	 */
+     * Expect the method to called called exactly once.
+     *
+     * @return MockBuilder
+     */
     public function once()
     {
         return $this->exactly(1);
     }
 
     /**
-	 * @param string $method
-	 * @return MockBuilder
-	 */
+     * @param string $method
+     * @return MockBuilder
+     */
     public function expect($method)
     {
         ArgumentChecker::check($method, 'string');
 
         $this->reset();
         $this->isExpecting = true;
-        $this->addRule(func_get_args(), new Action\ReturnValueAction(array(null)));
+        $this->addRule(
+            func_get_args(),
+            new Action\ReturnValueAction(array(null))
+        );
         $this->once();
         foreach (func_get_args() as $method) {
             $this->rules[$method][$this->getWithKey()]['hasSetTimes'] = false;
@@ -300,35 +338,37 @@ class MockBuilder
     }
 
     /**
-	 * @return MockBuilder
-	 */
+     * @return MockBuilder
+     */
     public function expects()
     {
         return call_user_func_array(array($this, 'expect'), func_get_args());
     }
 
     /**
-	 * Expect the method to be called exactly twice.
-	 * @return MockBuilder
-	 */
+     * Expect the method to be called exactly twice.
+     *
+     * @return MockBuilder
+     */
     public function twice()
     {
         return $this->exactly(2);
     }
 
     /**
-	 * Expect that the method is never called.
-	 * @return MockBuilder
-	 */
+     * Expect that the method is never called.
+     *
+     * @return MockBuilder
+     */
     public function never()
     {
         return $this->exactly(0);
     }
 
     /**
-	 * @param integer $times
-	 * @return MockBuilder
-	 */
+     * @param integer $times
+     * @return MockBuilder
+     */
     public function exactly($times)
     {
         ArgumentChecker::check($times, 'integer');
@@ -343,15 +383,15 @@ class MockBuilder
 
     /**
      * @param Action\AbstractAction $action
-     * @param integer $times
+     * @param integer               $times
      */
     protected function setupWith(Action\AbstractAction $action, $times)
     {
         foreach ($this->currentRules as $rule) {
             $this->rules[$rule][$this->getWithKey()] = array(
-                'action'      => $action,
-                'times'       => $times,
-                'with'        => $this->currentWith,
+                'action' => $action,
+                'times' => $times,
+                'with' => $this->currentWith,
                 'hasSetTimes' => false,
             );
         }
@@ -359,13 +399,17 @@ class MockBuilder
 
     /**
      * Expected arguments when invoking the mock.
+     *
      * @throws \Exception
      * @return MockBuilder
      */
     public function with()
     {
         $methodArguments = new MethodArguments();
-        $this->currentWith = $methodArguments->getMethodArgumentValues(func_get_args(), $this->getClassName() . "::" . $this->currentRules[0]);
+        $this->currentWith = $methodArguments->getMethodArgumentValues(
+            func_get_args(),
+            $this->getClassName() . "::" . $this->currentRules[0]
+        );
         foreach ($this->currentRules as $rule) {
             if ($this->rules[$rule][md5('null')]['hasSetTimes']) {
                 $renderer = new ValueRenderer();
@@ -373,20 +417,29 @@ class MockBuilder
                 $args = $renderer->renderAll($this->currentWith);
                 $times = $this->rules[$rule][md5('null')]['times'];
                 $convertToMethod = $converter->convertToMethod($times);
-                throw new Exception(sprintf("%s:\n  ->expects('%s')->with(%s)->%s",
+                throw new Exception(
+                    sprintf(
+                        "%s:\n  ->expects('%s')->with(%s)->%s",
                         "When using with you must specify expectations for each with()",
-                        $rule, $args, $convertToMethod));
+                        $rule,
+                        $args,
+                        $convertToMethod
+                    )
+                );
             }
             $this->rules[$rule][md5('null')]['times'] = -1;
         }
-        $this->setupWith(new Action\ReturnValueAction(array(null)), $this->isExpecting ? 1 : -1);
+        $this->setupWith(
+            new Action\ReturnValueAction(array(null)),
+            $this->isExpecting ? 1 : -1
+        );
 
         return $this;
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getRules()
     {
         return $this->rules;
@@ -417,11 +470,13 @@ class MockBuilder
     public function disableConstructor()
     {
         if ($this->isInterface()) {
-            $message = "You cannot disable the constructor of an interface ({$this->className}).";
+            $message =
+                "You cannot disable the constructor of an interface ({$this->className}).";
             throw new Exception($message);
         }
         if ($this->isPartialMock()) {
-            $message = "You cannot disable the constructor on a partial mock because any " .
+            $message =
+                "You cannot disable the constructor on a partial mock because any " .
                 "constructor would have already run ({$this->className}).";
             throw new Exception($message);
         }
@@ -438,7 +493,9 @@ class MockBuilder
     public function expose()
     {
         if (!$this->niceMock) {
-            throw new Exception("You cannot expose a method on a mock that is not nice.");
+            throw new Exception(
+                "You cannot expose a method on a mock that is not nice."
+            );
         }
         foreach (func_get_args() as $arg) {
             if (!is_array($arg)) {
@@ -451,8 +508,8 @@ class MockBuilder
     }
 
     /**
-	 * @return MockBuilder
-	 */
+     * @return MockBuilder
+     */
     public function andReturnSelf()
     {
         return $this->setAction(new Action\ReturnSelfAction());
@@ -487,7 +544,9 @@ class MockBuilder
      */
     public function andReturnCallback(Closure $returnCallback)
     {
-        return $this->setAction(new Action\ReturnCallbackAction($returnCallback));
+        return $this->setAction(
+            new Action\ReturnCallbackAction($returnCallback)
+        );
     }
 
     /**
@@ -500,7 +559,8 @@ class MockBuilder
         ArgumentChecker::check($property, 'string');
 
         if ($this->isInterface()) {
-            $message = "You cannot return a property from an interface ({$this->className}).";
+            $message =
+                "You cannot return a property from an interface ({$this->className}).";
             throw new InvalidArgumentException($message);
         }
 
@@ -525,7 +585,7 @@ class MockBuilder
 
     /**
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      * @throws Exception
      * @return MockBuilder
      */

--- a/src/Concise/Mock/MockInterface.php
+++ b/src/Concise/Mock/MockInterface.php
@@ -3,9 +3,9 @@
 namespace Concise\Mock;
 
 /**
- * All mocks will implement this interface. It can be used to identity when mocks are replacing
- * real objects, and also provides the IDE with method definitions that are added on to the mocked
- * class.
+ * All mocks will implement this interface. It can be used to identity when
+ * mocks are replacing real objects, and also provides the IDE with method
+ * definitions that are added on to the mocked class.
  */
 interface MockInterface
 {

--- a/src/Concise/Mock/MockManager.php
+++ b/src/Concise/Mock/MockManager.php
@@ -64,8 +64,8 @@ class MockManager
     }
 
     /**
-     * @param array $rule
-     * @param int $actualTimes
+     * @param array  $rule
+     * @param int    $actualTimes
      * @param string $method
      * @return null
      */

--- a/src/Concise/Mock/MockManager.php
+++ b/src/Concise/Mock/MockManager.php
@@ -2,9 +2,9 @@
 
 namespace Concise\Mock;
 
-use Concise\TestCase;
 use Concise\Services\NumberToTimesConverter;
 use Concise\Services\ValueRenderer;
+use Concise\TestCase;
 use PHPUnit_Framework_AssertionFailedError;
 
 class MockManager
@@ -35,9 +35,9 @@ class MockManager
     }
 
     /**
-	 * @param MockBuilder $mockBuilder
-	 * @param object      $mockInstance
-	 */
+     * @param MockBuilder $mockBuilder
+     * @param object      $mockInstance
+     */
     public function addMockInstance(MockBuilder $mockBuilder, $mockInstance)
     {
         self::$mocks[] = array(
@@ -56,7 +56,9 @@ class MockManager
         $r = " Did receive:";
         $converter = new NumberToTimesConverter();
         foreach ($this->argumentsForCallKey as $key => $args) {
-            $r .= "\n\n" . $converter->convert($this->callGraph[$key]) . ": {$args['method']}(" . $this->renderArguments($args['args']) . ")";
+            $r .= "\n\n" . $converter->convert($this->callGraph[$key]) .
+                ": {$args['method']}(" . $this->renderArguments($args['args']) .
+                ")";
         }
         return $r;
     }
@@ -84,8 +86,11 @@ class MockManager
         throw new \PHPUnit_Framework_AssertionFailedError($msg);
     }
 
-    protected function getKeyForCall($methodName, array $arguments, array $expected)
-    {
+    protected function getKeyForCall(
+        $methodName,
+        array $arguments,
+        array $expected
+    ) {
         $count = count($expected);
         for ($i = 0; $i < $count; ++$i) {
             if ($expected[$i] === TestCase::ANYTHING) {
@@ -96,8 +101,11 @@ class MockManager
         return md5($methodName . json_encode($arguments));
     }
 
-    protected function incrementCallGraphForCall($methodName, array $call, array $expected)
-    {
+    protected function incrementCallGraphForCall(
+        $methodName,
+        array $call,
+        array $expected
+    ) {
         $key = $this->getKeyForCall($methodName, $call, $expected);
         if (!array_key_exists($key, $this->callGraph)) {
             $this->callGraph[$key] = 0;
@@ -137,7 +145,11 @@ class MockManager
         if (null === $rule['with']) {
             /** @var $instance \Concise\Mock\MockInterface */
             $instance = $mock['instance'];
-            $this->validateSingleWith($rule, count($instance->getCallsForMethod($method)), $method);
+            $this->validateSingleWith(
+                $rule,
+                count($instance->getCallsForMethod($method)),
+                $method
+            );
         } else {
             $this->validateMultiWith($method, $rule, $mock);
         }
@@ -203,12 +215,16 @@ class MockManager
         foreach (self::$mocks as &$m) {
             if ($mock === $m['instance']) {
                 if ($m['validated']) {
-                    throw new PHPUnit_Framework_AssertionFailedError('You cannot assert a mock more than once.');
+                    throw new PHPUnit_Framework_AssertionFailedError(
+                        'You cannot assert a mock more than once.'
+                    );
                 }
                 return $this->validateMock($m);
             }
         }
 
-        throw new PHPUnit_Framework_AssertionFailedError('No such mock in mock manager.');
+        throw new PHPUnit_Framework_AssertionFailedError(
+            'No such mock in mock manager.'
+        );
     }
 }

--- a/src/Concise/Mock/PrototypeBuilder.php
+++ b/src/Concise/Mock/PrototypeBuilder.php
@@ -2,17 +2,19 @@
 
 namespace Concise\Mock;
 
-use Reflection;
-use ReflectionParameter;
-use ReflectionMethod;
 use Concise\Validation\ArgumentChecker;
+use Reflection;
+use ReflectionMethod;
+use ReflectionParameter;
 
 class PrototypeBuilder
 {
     /**
-	 * If this is `true` then the `abstract` keyword will not be outputted in the prototypes.
-	 * @var boolean
-	 */
+     * If this is `true` then the `abstract` keyword will not be outputted in
+     * the prototypes.
+     *
+     * @var boolean
+     */
     public $hideAbstract = false;
 
     protected function getDefaultValue(ReflectionParameter $p)
@@ -52,13 +54,15 @@ class PrototypeBuilder
     }
 
     /**
-	 * Get the prototype for the method.
-	 * @param  ReflectionMethod $method
-	 * @return string
-	 */
+     * Get the prototype for the method.
+     *
+     * @param  ReflectionMethod $method
+     * @return string
+     */
     public function getPrototype(ReflectionMethod $method)
     {
-        $modifiers = implode(' ', Reflection::getModifierNames($method->getModifiers()));
+        $modifiers =
+            implode(' ', Reflection::getModifierNames($method->getModifiers()));
         if ($this->hideAbstract) {
             $modifiers = str_replace('abstract ', '', $modifiers);
         }
@@ -70,7 +74,8 @@ class PrototypeBuilder
             $parameters[] = $param;
         }
 
-        return $modifiers . ' function ' . $method->getName() . "(" . implode(', ', $parameters) . ")";
+        return $modifiers . ' function ' . $method->getName() . "(" .
+        implode(', ', $parameters) . ")";
     }
 
     /**

--- a/src/Concise/Services/AssertionBuilder.php
+++ b/src/Concise/Services/AssertionBuilder.php
@@ -2,21 +2,21 @@
 
 namespace Concise\Services;
 
-use Concise\Syntax\MatcherParser;
 use Concise\Assertion;
+use Concise\Syntax\MatcherParser;
 use Concise\Syntax\NoMatcherFoundException;
 use Exception;
 
 class AssertionBuilder
 {
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $args;
 
     /**
-	 * @param array $args
-	 */
+     * @param array $args
+     */
     public function __construct(array $args)
     {
         $this->args = $args;
@@ -68,7 +68,7 @@ class AssertionBuilder
 
     /**
      * @param array $syntax
-     * @param int $offset
+     * @param int   $offset
      * @return string
      */
     protected function getSyntaxString($syntax = array(), $offset = 0)
@@ -100,7 +100,10 @@ class AssertionBuilder
     {
         $syntax1 = explode(' ', $this->getSyntaxString());
         $syntax2 = explode(' ', $this->getAlternateSyntaxString());
-        $syntax = array_merge(array_slice($syntax1, 0, count($syntax1) - 2), array_slice($syntax2, count($syntax1) - 3));
+        $syntax = array_merge(
+            array_slice($syntax1, 0, count($syntax1) - 2),
+            array_slice($syntax2, count($syntax1) - 3)
+        );
         return implode(' ', $syntax);
     }
 
@@ -147,7 +150,10 @@ class AssertionBuilder
         $syntaxes = array();
         foreach ($this->getSyntaxes() as $syntax) {
             try {
-                return $matcherParser->compile($syntax['syntax'], $syntax['data']);
+                return $matcherParser->compile(
+                    $syntax['syntax'],
+                    $syntax['data']
+                );
             } catch (NoMatcherFoundException $e) {
                 // Syntax could not be compiled, try the next one.
                 $syntaxes = array_merge($syntaxes, $e->getSyntaxes());

--- a/src/Concise/Services/CharacterConverter.php
+++ b/src/Concise/Services/CharacterConverter.php
@@ -5,8 +5,8 @@ namespace Concise\Services;
 class CharacterConverter
 {
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $characterMap = array(
         'a' => "\a",
         'e' => "\e",
@@ -17,9 +17,9 @@ class CharacterConverter
     );
 
     /**
-	 * @param  string $ch A string character.
-	 * @return string
-	 */
+     * @param  string $ch A string character.
+     * @return string
+     */
     public function convertEscapedCharacter($ch)
     {
         // @test \cx : "control-x", where x is any character

--- a/src/Concise/Services/MatcherSyntaxAndDescription.php
+++ b/src/Concise/Services/MatcherSyntaxAndDescription.php
@@ -5,9 +5,9 @@ namespace Concise\Services;
 class MatcherSyntaxAndDescription
 {
     /**
-	 * @param  array $syntaxes
-	 * @return array
-	 */
+     * @param  array $syntaxes
+     * @return array
+     */
     public function process(array $syntaxes)
     {
         $r = array();

--- a/src/Concise/Services/SyntaxRenderer.php
+++ b/src/Concise/Services/SyntaxRenderer.php
@@ -8,10 +8,10 @@ use Concise\Validation\ArgumentChecker;
 class SyntaxRenderer
 {
     /**
-	 * @param string $syntax
-	 * @param array $data
-	 * @return string
-	 */
+     * @param string $syntax
+     * @param array  $data
+     * @return string
+     */
     public function render($syntax, array $data = array())
     {
         ArgumentChecker::check($syntax, 'string');
@@ -19,10 +19,14 @@ class SyntaxRenderer
         $renderer = new ValueRenderer();
         $renderer->setTheme(new DefaultTheme());
 
-        return preg_replace_callback('/\?/', function () use (&$data, $renderer) {
-            $r = $renderer->render(array_shift($data));
+        return preg_replace_callback(
+            '/\?/',
+            function () use (&$data, $renderer) {
+                $r = $renderer->render(array_shift($data));
 
-            return $r;
-        }, $syntax);
+                return $r;
+            },
+            $syntax
+        );
     }
 }

--- a/src/Concise/Services/TimeFormatter.php
+++ b/src/Concise/Services/TimeFormatter.php
@@ -15,11 +15,11 @@ class TimeFormatter
     }
 
     /**
-     * @param array $r
-     * @param int $seconds
+     * @param array   $r
+     * @param int     $seconds
      * @param integer $size
-     * @param string $word
-     * @param bool $pluralize
+     * @param string  $word
+     * @param bool    $pluralize
      */
     protected function part(array &$r, &$seconds, $size, $word, $pluralize)
     {
@@ -32,7 +32,8 @@ class TimeFormatter
 
     /**
      * @param integer $seconds
-     * @param bool $small Use shorter output, '3 min 20 sec' instead of '3 minutes 20 seconds'
+     * @param bool    $small Use shorter output, '3 min 20 sec' instead of '3
+     *     minutes 20 seconds'
      * @return string
      */
     public function format($seconds, $small = false)

--- a/src/Concise/Services/ValueDescriptor.php
+++ b/src/Concise/Services/ValueDescriptor.php
@@ -5,9 +5,9 @@ namespace Concise\Services;
 class ValueDescriptor
 {
     /**
-	 * @param  mixed $value
-	 * @return string
-	 */
+     * @param  mixed $value
+     * @return string
+     */
     public function describe($value)
     {
         if (is_object($value)) {

--- a/src/Concise/Services/ValueRenderer.php
+++ b/src/Concise/Services/ValueRenderer.php
@@ -3,8 +3,8 @@
 namespace Concise\Services;
 
 use Closure;
-use Concise\Console\Theme\DefaultTheme;
 use Colors\Color;
+use Concise\Console\Theme\DefaultTheme;
 use Concise\TestCase;
 
 class ValueRenderer
@@ -24,7 +24,7 @@ class ValueRenderer
         $lines = explode("\n", $value);
         $string = array();
         foreach ($lines as $line) {
-            $string[] = (string) $c($line)->{$this->theme['value.string']};
+            $string[] = (string)$c($line)->{$this->theme['value.string']};
         }
 
         return implode("\n", $string);
@@ -38,35 +38,41 @@ class ValueRenderer
     {
         $c = new Color();
         if (!$this->theme) {
-            return (is_null($value) || is_bool($value)) ? json_encode($value) : (string) $value;
+            return (is_null($value) || is_bool($value)) ? json_encode($value)
+                : (string)$value;
         }
         if (is_null($value)) {
-            return (string) $c('null')->{$this->theme['value.null']};
+            return (string)$c('null')->{$this->theme['value.null']};
         }
         if (is_bool($value)) {
-            return (string) $c(json_encode($value))->{$this->theme['value.boolean']};
+            return (string)$c(
+                json_encode($value)
+            )->{$this->theme['value.boolean']};
         }
         if (is_int($value)) {
-            return (string) $c($value)->{$this->theme['value.integer']};
+            return (string)$c($value)->{$this->theme['value.integer']};
         }
         if (is_float($value)) {
-            return (string) $c($value)->{$this->theme['value.float']};
+            return (string)$c($value)->{$this->theme['value.float']};
         }
         if (is_resource($value)) {
-            return (string) $c((string) $value)->{$this->theme['value.string']};
+            return (string)$c((string)$value)->{$this->theme['value.string']};
         }
 
         return $this->colorizeLines($value);
     }
 
     /**
-     * @param array $values
+     * @param array   $values
      * @param integer $depth
      * @param Closure $callback
      * @return string
      */
-    protected function jsonEncodeCallback(array $values, $depth, Closure $callback)
-    {
+    protected function jsonEncodeCallback(
+        array $values,
+        $depth,
+        Closure $callback
+    ) {
         $r = '';
         foreach ($values as $k => $v) {
             if ($r) {
@@ -88,25 +94,36 @@ class ValueRenderer
     }
 
     /**
-     * @param mixed $value
+     * @param mixed   $value
      * @param integer $depth
      * @return string
      */
     protected function jsonEncode($value, $depth)
     {
         $self = $this;
-        if (is_object($value) || (is_array($value) && $this->isAssociativeArray($value))) {
-            $r = $this->jsonEncodeCallback((array) $value, $depth + 1, function ($k, $v) use ($depth, $self) {
-                return $self->colorize("\"$k\"") . ':' . $self->render($v, false, $depth + 1);
-            });
+        if (is_object($value) ||
+            (is_array($value) && $this->isAssociativeArray($value))
+        ) {
+            $r = $this->jsonEncodeCallback(
+                (array)$value,
+                $depth + 1,
+                function ($k, $v) use ($depth, $self) {
+                    return $self->colorize("\"$k\"") . ':' .
+                    $self->render($v, false, $depth + 1);
+                }
+            );
 
             return "{\n" . $r . "\n" . $this->createIndent($depth) . "}";
         }
 
         /** @noinspection PhpUnusedParameterInspection */
-        $r = $this->jsonEncodeCallback((array) $value, $depth + 1, function ($k, $v) use ($depth, $self) {
-            return $self->render($v, false, $depth + 1);
-        });
+        $r = $this->jsonEncodeCallback(
+            (array)$value,
+            $depth + 1,
+            function ($k, $v) use ($depth, $self) {
+                return $self->render($v, false, $depth + 1);
+            }
+        );
 
         return "[\n$r\n" . $this->createIndent($depth) . "]";
     }
@@ -139,24 +156,26 @@ class ValueRenderer
     protected function renderClosure()
     {
         $c = new Color();
-        return ($this->theme ? $c('function')->{$this->theme['value.closure']} : 'function');
+        return ($this->theme ? $c('function')->{$this->theme['value.closure']}
+            : 'function');
     }
 
     /**
      * @param boolean $showTypeHint
-     * @param object $value
+     * @param object  $value
      * @param integer $depth
      * @return string
      */
     protected function renderObject($showTypeHint, $value, $depth)
     {
-        return ($showTypeHint ? get_class($value) . ':' : '') . $this->jsonEncode($value, $depth);
+        return ($showTypeHint ? get_class($value) . ':' : '') .
+        $this->jsonEncode($value, $depth);
     }
 
     /**
      * @param  mixed $value
-     * @param bool $showTypeHint
-     * @param int $depth
+     * @param bool   $showTypeHint
+     * @param int    $depth
      * @return string
      */
     public function render($value, $showTypeHint = true, $depth = 0)

--- a/src/Concise/Syntax/Lexer.php
+++ b/src/Concise/Syntax/Lexer.php
@@ -9,13 +9,13 @@ use Exception;
 class Lexer
 {
     /**
-	 * @var \Concise\Syntax\MatcherParser
-	 */
+     * @var \Concise\Syntax\MatcherParser
+     */
     protected $matcherParser = null;
 
     /**
-	 * @return \Concise\Syntax\MatcherParser
-	 */
+     * @return \Concise\Syntax\MatcherParser
+     */
     protected function getMatcherParser()
     {
         if (null === $this->matcherParser) {
@@ -26,9 +26,9 @@ class Lexer
     }
 
     /**
-	 * @param string $token
-	 * @return bool
-	 */
+     * @param string $token
+     * @return bool
+     */
     protected function isKeyword($token)
     {
         return in_array($token, $this->getMatcherParser()->getKeywords());
@@ -36,29 +36,38 @@ class Lexer
 
     /**
      * @param boolean $mustConsumeUntil
-     * @param string $until
+     * @param string  $until
      * @throws Exception
      */
-    protected function throwExceptionIfWeMustConsumeUntil($mustConsumeUntil, $until)
-    {
+    protected function throwExceptionIfWeMustConsumeUntil(
+        $mustConsumeUntil,
+        $until
+    ) {
         if ($mustConsumeUntil) {
             throw new Exception("Expected $until before end of string.");
         }
     }
 
     /**
-	 * @param  string $string
-	 * @param  string $until A single character.
-	 * @param  integer $startIndex
-	 * @param  boolean $mustConsumeUntil
-	 * @return string
-	 */
-    protected function consumeUntilToken($string, $until, &$startIndex, $mustConsumeUntil = true)
-    {
+     * @param  string  $string
+     * @param  string  $until A single character.
+     * @param  integer $startIndex
+     * @param  boolean $mustConsumeUntil
+     * @return string
+     */
+    protected function consumeUntilToken(
+        $string,
+        $until,
+        &$startIndex,
+        $mustConsumeUntil = true
+    ) {
         $t = '';
         for ($i = $startIndex + 1; $string[$i] != $until; ++$i) {
             if ($i == strlen($string) - 1) {
-                $this->throwExceptionIfWeMustConsumeUntil($mustConsumeUntil, $until);
+                $this->throwExceptionIfWeMustConsumeUntil(
+                    $mustConsumeUntil,
+                    $until
+                );
                 $t .= $string[$i];
                 break;
             }
@@ -76,55 +85,66 @@ class Lexer
     }
 
     /**
-     * @param array $tokens
-	 * @param  string $string
-	 * @param  integer $startIndex
-	 * @return string
-	 */
+     * @param array    $tokens
+     * @param  string  $string
+     * @param  integer $startIndex
+     * @return string
+     */
     protected function consumeString(array &$tokens, $string, &$startIndex)
     {
         if ($string[$startIndex] === '"' || $string[$startIndex] === "'") {
-            $tokens[] = new Token\Value($this->consumeUntilToken($string, $string[$startIndex], $startIndex));
+            $tokens[] = new Token\Value(
+                $this->consumeUntilToken(
+                    $string,
+                    $string[$startIndex],
+                    $startIndex
+                )
+            );
         }
     }
 
     /**
-     * @param array $tokens
-	 * @param  string $string
-	 * @param  integer $startIndex
-	 * @return string
-	 */
+     * @param array    $tokens
+     * @param  string  $string
+     * @param  integer $startIndex
+     * @return string
+     */
     protected function consumeClassName(array &$tokens, $string, &$startIndex)
     {
         if ($string[$startIndex] === "\\") {
-            $tokens[] = new Token\Value($this->consumeUntilToken($string, ' ', $startIndex, false));
+            $tokens[] = new Token\Value(
+                $this->consumeUntilToken($string, ' ', $startIndex, false)
+            );
         }
     }
 
     /**
-     * @param array $tokens
-	 * @param  string $string
-	 * @param  integer $startIndex
-	 * @return string
-	 */
+     * @param array    $tokens
+     * @param  string  $string
+     * @param  integer $startIndex
+     * @return string
+     */
     protected function consumeRegexp(array &$tokens, $string, &$startIndex)
     {
         if ($string[$startIndex] === '/') {
-            $tokens[] = new Token\Regexp('/' . $this->consumeUntilToken($string, '/', $startIndex) . '/');
+            $tokens[] = new Token\Regexp(
+                '/' . $this->consumeUntilToken($string, '/', $startIndex) . '/'
+            );
         }
     }
 
     /**
-	 * @param string $t
-	 * @return Token
-	 */
+     * @param string $t
+     * @return Token
+     */
     protected function translateValue($t)
     {
         if ($this->isKeyword($t)) {
             return new Token\Keyword($t);
         }
-        if(preg_match('/^\-?[0-9]*\.[0-9]+([eE][\-+]?[0-9]+)?$/', $t) ||
-            preg_match('/^\-?[0-9]+([eE][\-+]?[0-9]+)?$/', $t)) {
+        if (preg_match('/^\-?[0-9]*\.[0-9]+([eE][\-+]?[0-9]+)?$/', $t) ||
+            preg_match('/^\-?[0-9]+([eE][\-+]?[0-9]+)?$/', $t)
+        ) {
             return new Token\Value($t * 1);
         }
 
@@ -132,8 +152,8 @@ class Lexer
     }
 
     /**
-     * @param array $tokens
-     * @param  string $string
+     * @param array    $tokens
+     * @param  string  $string
      * @param  integer $startIndex
      * @throws Exception
      * @return string
@@ -154,14 +174,16 @@ class Lexer
                     return;
                 }
             }
-            throw new Exception("Invalid JSON: " . substr($string, $originalStartIndex));
+            throw new Exception(
+                "Invalid JSON: " . substr($string, $originalStartIndex)
+            );
         }
     }
 
     /**
-     * @param array $tokens
+     * @param array  $tokens
      * @param string $string
-     * @param int $startIndex
+     * @param int    $startIndex
      * @throws Exception
      * @return bool
      */
@@ -177,7 +199,7 @@ class Lexer
     }
 
     /**
-     * @param array $tokens
+     * @param array  $tokens
      * @param string $token
      */
     protected function addTokenIfNotEmpty(array &$tokens, $token)
@@ -189,9 +211,9 @@ class Lexer
     }
 
     /**
-	 * @param  string $string
-	 * @return array
-	 */
+     * @param  string $string
+     * @return array
+     */
     protected function getTokens($string)
     {
         $r = array();
@@ -215,9 +237,9 @@ class Lexer
     }
 
     /**
-	 * @param  string $string
-	 * @return array
-	 */
+     * @param  string $string
+     * @return array
+     */
     protected function getAttributes($string)
     {
         $tokens = $this->getTokens($string);
@@ -237,9 +259,9 @@ class Lexer
     }
 
     /**
-	 * @param  string $string
-	 * @return string
-	 */
+     * @param  string $string
+     * @return string
+     */
     protected function getSyntax($string)
     {
         $tokens = $this->getTokens($string);
@@ -256,9 +278,9 @@ class Lexer
     }
 
     /**
-	 * @param  string $string
-	 * @return array
-	 */
+     * @param  string $string
+     * @return array
+     */
     public function parse($string)
     {
         ArgumentChecker::check($string, 'string');
@@ -271,8 +293,8 @@ class Lexer
     }
 
     /**
-	 * @param \Concise\Syntax\MatcherParser $matcherParser
-	 */
+     * @param \Concise\Syntax\MatcherParser $matcherParser
+     */
     public function setMatcherParser(MatcherParser $matcherParser)
     {
         $this->matcherParser = $matcherParser;

--- a/src/Concise/Syntax/MatcherParser.php
+++ b/src/Concise/Syntax/MatcherParser.php
@@ -90,7 +90,7 @@ class MatcherParser
     }
 
     /**
-     * @param array $data The data from the test case.
+     * @param array  $data The data from the test case.
      * @param string $string
      * @return \Concise\Assertion
      */

--- a/src/Concise/Syntax/MatcherParser.php
+++ b/src/Concise/Syntax/MatcherParser.php
@@ -3,8 +3,8 @@
 namespace Concise\Syntax;
 
 use Concise\Assertion;
-use Concise\Services\MatcherSyntaxAndDescription;
 use Concise\Matcher\AbstractMatcher;
+use Concise\Services\MatcherSyntaxAndDescription;
 use Concise\Validation\ArgumentChecker;
 use Exception;
 use ReflectionClass;
@@ -13,28 +13,28 @@ use ReflectionException;
 class MatcherParser
 {
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $matchers = array();
 
     /**
-	 * @var MatcherParser
-	 */
+     * @var MatcherParser
+     */
     protected static $instance = null;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $keywords = array();
 
     /**
-	 * @var Lexer
-	 */
+     * @var Lexer
+     */
     protected $lexer;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $syntaxCache = array();
 
     public function __construct()
@@ -44,9 +44,9 @@ class MatcherParser
     }
 
     /**
-	 * @param  string $syntax
-	 * @return string
-	 */
+     * @param  string $syntax
+     * @return string
+     */
     protected function getRawSyntax($syntax)
     {
         return preg_replace('/\\?:[^\s$]+/i', '?', $syntax);
@@ -59,12 +59,13 @@ class MatcherParser
      */
     protected function endsWith($string, $substring)
     {
-        return (substr($string, strlen($string) - strlen($substring)) === $substring);
+        return (substr($string, strlen($string) - strlen($substring)) ===
+            $substring);
     }
 
     /**
      * @param string $syntax
-     * @param array $data
+     * @param array  $data
      * @throws Exception
      * @return array
      */
@@ -76,7 +77,8 @@ class MatcherParser
         $endsWith = ' on error ?';
         $options = array();
         if ($this->endsWith($rawSyntax, $endsWith)) {
-            $rawSyntax = substr($rawSyntax, 0, strlen($rawSyntax) - strlen($endsWith));
+            $rawSyntax =
+                substr($rawSyntax, 0, strlen($rawSyntax) - strlen($endsWith));
             $options = array(
                 'on_error' => $data[count($data) - 1],
             );
@@ -88,17 +90,18 @@ class MatcherParser
     }
 
     /**
-	 * @param array $data The data from the test case.
-	 * @param string $string
-	 * @return \Concise\Assertion
-	 */
+     * @param array $data The data from the test case.
+     * @param string $string
+     * @return \Concise\Assertion
+     */
     public function compile($string, array $data = array())
     {
         $result = $this->lexer->parse($string);
-        $match = $this->getMatcherForSyntax($result['syntax'], $result['arguments']);
+        $match =
+            $this->getMatcherForSyntax($result['syntax'], $result['arguments']);
         $assertion = new Assertion($string, $match['matcher'], $data);
         if (array_key_exists('on_error', $match)) {
-            $assertion->setFailureMessage($data[(string) $match['on_error']]);
+            $assertion->setFailureMessage($data[(string)$match['on_error']]);
         }
         $assertion->setOriginalSyntax($match['originalSyntax']);
 
@@ -112,22 +115,27 @@ class MatcherParser
 
     /**
      * @param string $rawSyntax
-     * @throws Exception if the assertion contains words that are not lower case.
+     * @throws Exception if the assertion contains words that are not lower
+     *     case.
      */
     protected function throwExceptionIfNotInLowerCase($rawSyntax)
     {
         if (strtolower($rawSyntax) != $rawSyntax) {
-            throw new Exception("All assertions ('$rawSyntax') must be lower case.");
+            throw new Exception(
+                "All assertions ('$rawSyntax') must be lower case."
+            );
         }
     }
 
     /**
      * @param string $rawSyntax
-     * @param $syntax
+     * @param        $syntax
      * @throws Exception
      */
-    protected function throwExceptionIfSyntaxIsAlreadyDeclared($rawSyntax, $syntax)
-    {
+    protected function throwExceptionIfSyntaxIsAlreadyDeclared(
+        $rawSyntax,
+        $syntax
+    ) {
         if (array_key_exists($rawSyntax, $this->syntaxCache)) {
             throw new Exception("Syntax '$syntax' is already declared.");
         }
@@ -145,13 +153,14 @@ class MatcherParser
     }
 
     /**
-	 * @param  \Concise\Matcher\AbstractMatcher $matcher
-	 * @return boolean
-	 */
+     * @param  \Concise\Matcher\AbstractMatcher $matcher
+     * @return boolean
+     */
     public function registerMatcher(AbstractMatcher $matcher)
     {
         $service = new MatcherSyntaxAndDescription();
-        $allSyntaxes = array_keys($service->process($matcher->supportedSyntaxes()));
+        $allSyntaxes =
+            array_keys($service->process($matcher->supportedSyntaxes()));
         foreach ($allSyntaxes as $syntax) {
             $this->registerSyntax($syntax, $matcher);
         }
@@ -163,8 +172,8 @@ class MatcherParser
     }
 
     /**
-	 * @return MatcherParser
-	 */
+     * @return MatcherParser
+     */
     public static function getInstance()
     {
         if (null === self::$instance) {
@@ -184,8 +193,8 @@ class MatcherParser
         try {
             $reflectionClass = new ReflectionClass($class);
             return !$reflectionClass->isAbstract() &&
-                is_subclass_of($class, 'Concise\Matcher\AbstractMatcher') &&
-                $class != 'Concise\Matcher\AbstractNestedMatcher';
+            is_subclass_of($class, 'Concise\Matcher\AbstractMatcher') &&
+            $class != 'Concise\Matcher\AbstractNestedMatcher';
         } catch (ReflectionException $e) {
             return false;
         }
@@ -211,8 +220,8 @@ class MatcherParser
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getMatchers()
     {
         return $this->matchers;
@@ -233,8 +242,8 @@ class MatcherParser
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     protected function getRawKeywords()
     {
         $r = array('error', 'on');
@@ -251,8 +260,8 @@ class MatcherParser
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getKeywords()
     {
         if (0 === count($this->keywords)) {
@@ -263,8 +272,8 @@ class MatcherParser
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getAllMatcherDescriptions()
     {
         $r = array();

--- a/src/Concise/Syntax/NoMatcherFoundException.php
+++ b/src/Concise/Syntax/NoMatcherFoundException.php
@@ -13,7 +13,9 @@ class NoMatcherFoundException extends Exception
 
     public function __construct(array $syntaxes)
     {
-        $message = "No such matcher for syntax '" . implode("' or '", $syntaxes) . "'.";
+        $message =
+            "No such matcher for syntax '" . implode("' or '", $syntaxes) .
+            "'.";
         parent::__construct($message);
         $this->syntaxes = $syntaxes;
     }

--- a/src/Concise/Syntax/Token.php
+++ b/src/Concise/Syntax/Token.php
@@ -5,31 +5,31 @@ namespace Concise\Syntax;
 class Token
 {
     /**
-	 * @var mixed
-	 */
+     * @var mixed
+     */
     protected $value;
 
     /**
-	 * @param mixed $value
-	 */
+     * @param mixed $value
+     */
     public function __construct($value = null)
     {
         $this->value = $value;
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function getValue()
     {
         return $this->value;
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     public function __toString()
     {
-        return (string) $this->getValue();
+        return (string)$this->getValue();
     }
 }

--- a/src/Concise/Syntax/Token/Attribute.php
+++ b/src/Concise/Syntax/Token/Attribute.php
@@ -7,13 +7,13 @@ use Concise\Syntax\Token;
 class Attribute extends Token
 {
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $acceptedTypes = array();
 
     /**
-	 * @param string $value
-	 */
+     * @param string $value
+     */
     public function __construct($value)
     {
         parent::__construct($value);
@@ -25,8 +25,8 @@ class Attribute extends Token
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getAcceptedTypes()
     {
         return $this->acceptedTypes;

--- a/src/Concise/TestCase.php
+++ b/src/Concise/TestCase.php
@@ -3,15 +3,15 @@
 namespace Concise;
 
 use Concise\Mock\MockBuilder;
+use Concise\Mock\MockInterface;
+use Concise\Mock\MockManager;
 use Concise\Services\AssertionBuilder;
 use Concise\Syntax\MatcherParser;
-use Concise\Mock\MockManager;
 use Concise\Validation\ArgumentChecker;
 use Exception;
 use PHPUnit_Framework_AssertionFailedError;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
-use Concise\Mock\MockInterface;
 use ReflectionException;
 
 // Load the keyword cache before the test suite begins.
@@ -20,14 +20,15 @@ Keywords::load();
 class TestCase extends PHPUnit_Framework_TestCase
 {
     /**
-     * Used as a placeholder for with() clauses where the parameter is unrestrictive. For the
-     * curious, this is the SHA1('a') with an extra 'a' on the end.
+     * Used as a placeholder for with() clauses where the parameter is
+     * unrestrictive. For the curious, this is the SHA1('a') with an extra 'a'
+     * on the end.
      */
     const ANYTHING = '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8a';
 
     /**
-	 * @var MockManager
-	 */
+     * @var MockManager
+     */
     protected $mockManager;
 
     /**
@@ -42,11 +43,14 @@ class TestCase extends PHPUnit_Framework_TestCase
 
     /**
      * @param string|null $name
-     * @param array $data
-     * @param string $dataName
+     * @param array       $data
+     * @param string      $dataName
      */
-    public function __construct($name = null, array $data = array(), $dataName = '')
-    {
+    public function __construct(
+        $name = null,
+        array $data = array(),
+        $dataName = ''
+    ) {
         parent::__construct($name, $data, $dataName);
         $this->mockManager = new MockManager($this);
     }
@@ -60,8 +64,8 @@ class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-	 * @return MatcherParser
-	 */
+     * @return MatcherParser
+     */
     protected function getMatcherParserInstance()
     {
         return MatcherParser::getInstance();
@@ -93,29 +97,31 @@ class TestCase extends PHPUnit_Framework_TestCase
 
     /**
      * @param string $name
-     * @param mixed $value
+     * @param mixed  $value
      * @throws Exception
      */
     public function __set($name, $value)
     {
         $parser = $this->getMatcherParserInstance();
         if (in_array($name, $parser->getKeywords())) {
-            throw new Exception("You cannot assign an attribute with the keyword '$name'.");
+            throw new Exception(
+                "You cannot assign an attribute with the keyword '$name'."
+            );
         }
         $this->properties[$name] = $value;
     }
 
     /**
-	 * @return array
-	 */
+     * @return array
+     */
     public function getData()
     {
         return $this->properties + get_object_vars($this);
     }
 
     /**
-	 * @return string
-	 */
+     * @return string
+     */
     protected function getRealTestName()
     {
         $name = substr($this->getName(), 20);
@@ -125,9 +131,10 @@ class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-	 * These attributes are provided by the base PHPUnit classes.
-	 * @return array
-	 */
+     * These attributes are provided by the base PHPUnit classes.
+     *
+     * @return array
+     */
     public static function getPHPUnitProperties()
     {
         return array(
@@ -147,12 +154,15 @@ class TestCase extends PHPUnit_Framework_TestCase
             return $builder->getAssertion();
         }
 
-        return $this->getMatcherParserInstance()->compile($args[0], $this->getData());
+        return $this->getMatcherParserInstance()->compile(
+            $args[0],
+            $this->getData()
+        );
     }
 
     /**
      * @return boolean
-	 */
+     */
     public function assert()
     {
         $assertion = $this->createAssertion(func_get_args());
@@ -170,7 +180,8 @@ class TestCase extends PHPUnit_Framework_TestCase
         $this->mockManager->validateMocks();
         if ($this->verifyFailures) {
             $count = count($this->verifyFailures);
-            $message = "$count verify failure" . ($count === 1 ? '' : 's') . ":";
+            $message =
+                "$count verify failure" . ($count === 1 ? '' : 's') . ":";
             $message .= "\n\n" . implode("\n\n", $this->verifyFailures);
             throw new PHPUnit_Framework_AssertionFailedError($message);
         }
@@ -178,22 +189,26 @@ class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
-	 * @param  string $className
-	 * @param  array  $constructorArgs
-	 * @return MockBuilder
-	 */
-    public function mock($className = '\stdClass', array $constructorArgs = array())
-    {
+     * @param  string $className
+     * @param  array  $constructorArgs
+     * @return MockBuilder
+     */
+    public function mock(
+        $className = '\stdClass',
+        array $constructorArgs = array()
+    ) {
         return new MockBuilder($this, $className, false, $constructorArgs);
     }
 
     /**
-	 * @param  string $className
-	 * @param  array  $constructorArgs
-	 * @return MockBuilder
-	 */
-    public function niceMock($className = '\stdClass', array $constructorArgs = array())
-    {
+     * @param  string $className
+     * @param  array  $constructorArgs
+     * @return MockBuilder
+     */
+    public function niceMock(
+        $className = '\stdClass',
+        array $constructorArgs = array()
+    ) {
         return new MockBuilder($this, $className, true, $constructorArgs);
     }
 
@@ -204,7 +219,8 @@ class TestCase extends PHPUnit_Framework_TestCase
     public function partialMock($instance)
     {
         ArgumentChecker::check($instance, 'object');
-        $mockBuilder = new MockBuilder($this, get_class($instance), true, array());
+        $mockBuilder =
+            new MockBuilder($this, get_class($instance), true, array());
         $mockBuilder->disableConstructor();
         $mockBuilder->setObjectState($instance);
         return $mockBuilder;
@@ -215,8 +231,10 @@ class TestCase extends PHPUnit_Framework_TestCase
         $parser = MatcherParser::getInstance();
 
         $all = array();
-        foreach ($parser->getAllMatcherDescriptions() as $syntax => $description) {
-            $simpleSyntax = preg_replace('/\\?(:[a-zA-Z0-9-,]+)/', '?', $syntax);
+        foreach ($parser->getAllMatcherDescriptions(
+        ) as $syntax => $description) {
+            $simpleSyntax =
+                preg_replace('/\\?(:[a-zA-Z0-9-,]+)/', '?', $syntax);
             foreach (explode('?', $simpleSyntax) as $part) {
                 $p = trim($part);
                 $all[str_replace(' ', '_', $p)] = $p;
@@ -252,7 +270,8 @@ class TestCase extends PHPUnit_Framework_TestCase
         if ($object instanceof MockInterface) {
             $className = get_parent_class($object);
             if (!$className) {
-                $message = "You cannot set a property on an interface (" . get_class($object) . ").";
+                $message = "You cannot set a property on an interface (" .
+                    get_class($object) . ").";
                 throw new Exception($message);
             }
         }
@@ -265,8 +284,8 @@ class TestCase extends PHPUnit_Framework_TestCase
 
     protected function shouldAccessProperty($object, $property)
     {
-        return property_exists($object, $property)
-            || method_exists($object, '__get');
+        return property_exists($object, $property) ||
+        method_exists($object, '__get');
     }
 
     public function getProperty($object, $property)
@@ -295,6 +314,7 @@ class TestCase extends PHPUnit_Framework_TestCase
 
     /**
      * Validate a mock now.
+     *
      * @param  MockInterface $mock The mock instance to verify.
      * @return bool
      */

--- a/src/Concise/TestCase.php
+++ b/src/Concise/TestCase.php
@@ -231,8 +231,7 @@ class TestCase extends PHPUnit_Framework_TestCase
         $parser = MatcherParser::getInstance();
 
         $all = array();
-        foreach ($parser->getAllMatcherDescriptions(
-        ) as $syntax => $description) {
+        foreach ($parser->getAllMatcherDescriptions() as $syntax => $description) {
             $simpleSyntax =
                 preg_replace('/\\?(:[a-zA-Z0-9-,]+)/', '?', $syntax);
             foreach (explode('?', $simpleSyntax) as $part) {

--- a/src/Concise/Validation/ArgumentChecker.php
+++ b/src/Concise/Validation/ArgumentChecker.php
@@ -18,7 +18,9 @@ class ArgumentChecker
         try {
             return $checker->check(explode(',', $types), $value);
         } catch (DataTypeMismatchException $e) {
-            throw new InvalidArgumentException($e->getMessage() . " for argument {$argumentNumber}");
+            throw new InvalidArgumentException(
+                $e->getMessage() . " for argument {$argumentNumber}"
+            );
         }
     }
 }

--- a/src/Concise/Validation/ArgumentChecker.php
+++ b/src/Concise/Validation/ArgumentChecker.php
@@ -7,9 +7,9 @@ use InvalidArgumentException;
 class ArgumentChecker
 {
     /**
-     * @param mixed $value
+     * @param mixed  $value
      * @param string $types comma-separated.
-     * @param int $argumentNumber
+     * @param int    $argumentNumber
      */
     public static function check($value, $types, $argumentNumber = 1)
     {

--- a/src/Concise/Validation/DataTypeChecker.php
+++ b/src/Concise/Validation/DataTypeChecker.php
@@ -9,42 +9,46 @@ use Exception;
 class DataTypeChecker
 {
     /**
-	 * @var boolean
-	 */
+     * @var boolean
+     */
     protected $excludeMode = false;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $context = array();
 
     /**
-	 * @param array $context
-	 */
+     * @param array $context
+     */
     public function setContext(array $context)
     {
         $this->context = $context;
     }
 
     /**
-	 * @param  array $acceptedTypes
-	 * @param  mixed $value
-	 * @return mixed
-	 */
+     * @param  array $acceptedTypes
+     * @param  mixed $value
+     * @return mixed
+     */
     public function check(array $acceptedTypes, $value)
     {
         if (count($acceptedTypes) === 0) {
             return $value;
         }
 
-        return $this->throwInvalidArgumentException($acceptedTypes, $value, !$this->excludeMode);
+        return $this->throwInvalidArgumentException(
+            $acceptedTypes,
+            $value,
+            !$this->excludeMode
+        );
     }
 
     /**
-	 * @param  array $acceptedTypes
-	 * @param  mixed $value
-	 * @return bool
-	 */
+     * @param  array $acceptedTypes
+     * @param  mixed $value
+     * @return bool
+     */
     protected function matchesInAcceptedTypes(array $acceptedTypes, $value)
     {
         foreach ($acceptedTypes as $acceptedType) {
@@ -57,9 +61,11 @@ class DataTypeChecker
     }
 
     /**
-     * Will check to see if the value is an object and its class is listed in the accepted types.
-     * @param  array       $acceptedTypes Accepted types.
-     * @param  mixed       $value         Value to test.
+     * Will check to see if the value is an object and its class is listed in
+     * the accepted types.
+     *
+     * @param  array $acceptedTypes Accepted types.
+     * @param  mixed $value Value to test.
      * @return null|object
      */
     protected function checkSpecificObject(array $acceptedTypes, $value)
@@ -77,8 +83,8 @@ class DataTypeChecker
     }
 
     /**
-     * @param array $acceptedTypes
-     * @param $value
+     * @param array   $acceptedTypes
+     * @param         $value
      * @param boolean $expecting
      * @throws Exception
      * @return string
@@ -92,7 +98,9 @@ class DataTypeChecker
             }
             if (in_array('class', $acceptedTypes) && is_string($value)) {
                 if (!class_exists($value) && !interface_exists($value)) {
-                    throw new Exception("No such class or interface '$value'.'");
+                    throw new Exception(
+                        "No such class or interface '$value'.'"
+                    );
                 }
                 return ltrim($value, '\\');
             }
@@ -103,17 +111,23 @@ class DataTypeChecker
             return $value;
         }
 
-        throw new DataTypeMismatchException($this->getType($value), $acceptedTypes);
+        throw new DataTypeMismatchException(
+            $this->getType($value),
+            $acceptedTypes
+        );
     }
 
     /**
-	 * @param  array  $acceptedTypes
-	 * @param  mixed  $value
-	 * @param  bool   $expecting
-	 * @return mixed
-	 */
-    protected function throwInvalidArgumentException(array $acceptedTypes, $value, $expecting)
-    {
+     * @param  array $acceptedTypes
+     * @param  mixed $value
+     * @param  bool  $expecting
+     * @return mixed
+     */
+    protected function throwInvalidArgumentException(
+        array $acceptedTypes,
+        $value,
+        $expecting
+    ) {
         if (($r = $this->checkSpecificObject($acceptedTypes, $value))) {
             return $r;
         }
@@ -137,18 +151,20 @@ class DataTypeChecker
 
     protected function isRegex($value)
     {
-        return is_object($value) && get_class($value) === 'Concise\Syntax\Token\Regexp';
+        return is_object($value) &&
+        get_class($value) === 'Concise\Syntax\Token\Regexp';
     }
 
     protected function isAttribute($value)
     {
-        return is_object($value) && get_class($value) === 'Concise\Syntax\Token\Attribute';
+        return is_object($value) &&
+        get_class($value) === 'Concise\Syntax\Token\Attribute';
     }
 
     /**
-	 * @param  mixed $value
-	 * @return string
-	 */
+     * @param  mixed $value
+     * @return string
+     */
     protected function getType($value)
     {
         if ($this->isRegex($value)) {
@@ -165,41 +181,42 @@ class DataTypeChecker
     }
 
     /**
-	 * @param  string $type
-	 * @param  string $value
-	 * @return bool
-	 */
+     * @param  string $type
+     * @param  string $value
+     * @return bool
+     */
     protected function singleMatch($type, $value)
     {
         return $type === $this->simpleType($this->getType($value));
     }
 
     /**
-	 * @param  string $type
-	 * @param  mixed $value
-	 * @return bool
-	 */
+     * @param  string $type
+     * @param  mixed  $value
+     * @return bool
+     */
     protected function matches($type, $value)
     {
         if ($type === 'number') {
-            return $this->singleMatch('int', $value) || $this->singleMatch('float', $value) || is_numeric($value);
+            return $this->singleMatch('int', $value) ||
+            $this->singleMatch('float', $value) || is_numeric($value);
         }
 
         return $this->singleMatch($this->simpleType($type), $value);
     }
 
     /**
-	 * @param  string $type
-	 * @return string
-	 */
+     * @param  string $type
+     * @return string
+     */
     protected function simpleType($type)
     {
         $aliases = array(
             'integer' => 'int',
-            'double'  => 'float',
-            'class'   => 'string',
-            'bool'    => 'boolean',
-            'regex'   => 'string',
+            'double' => 'float',
+            'class' => 'string',
+            'bool' => 'boolean',
+            'regex' => 'string',
         );
         if (array_key_exists($type, $aliases)) {
             return $aliases[$type];

--- a/src/Concise/Validation/DataTypeMismatchException.php
+++ b/src/Concise/Validation/DataTypeMismatchException.php
@@ -10,8 +10,10 @@ class DataTypeMismatchException extends InvalidArgumentException
 
     protected $actualType;
 
-    public function __construct($actualType = 'unknown', array $expectedTypes = array())
-    {
+    public function __construct(
+        $actualType = 'unknown',
+        array $expectedTypes = array()
+    ) {
         $join = implode(' or ', $expectedTypes);
         parent::__construct("Expected $join, but got $actualType");
 

--- a/src/Concise/Version.php
+++ b/src/Concise/Version.php
@@ -35,7 +35,8 @@ class Version
             return '';
         }
 
-        $packages = json_decode(file_get_contents("$vendor/composer/installed.json"));
+        $packages =
+            json_decode(file_get_contents("$vendor/composer/installed.json"));
         foreach ($packages as $package) {
             if ($package->name === $packageName) {
                 return $package->version;

--- a/tests/Concise/AssertionOnErrorTest.php
+++ b/tests/Concise/AssertionOnErrorTest.php
@@ -21,7 +21,7 @@ class AssertionOnErrorTest extends TestCase
         try {
             $this->assert(123, equals, 124, on_error, 'foo');
             $this->fail('Did not fail.');
-        } catch(PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
             $this->assert($e->getMessage(), equals, 'foo');
         }
     }

--- a/tests/Concise/AssertionTest.php
+++ b/tests/Concise/AssertionTest.php
@@ -152,8 +152,7 @@ class AssertionTest extends TestCase
     /**
      * @group #219
      */
-    public function testDidNotMatchExceptionIsConvertedIntoAssertionFailedError(
-    )
+    public function testDidNotMatchExceptionIsConvertedIntoAssertionFailedError()
     {
         $self = $this;
         $block = function () use ($self) {
@@ -177,8 +176,7 @@ class AssertionTest extends TestCase
      * @expectedExceptionMessage foobar
      * @group #219
      */
-    public function testAnyOtherTypeOfExceptionIsNotConvertedToAssertionFailedError(
-    )
+    public function testAnyOtherTypeOfExceptionIsNotConvertedToAssertionFailedError()
     {
         $matcher = $this->mock('\Concise\Matcher\AbstractMatcher')
             ->stub('match')
@@ -186,8 +184,8 @@ class AssertionTest extends TestCase
             ->get();
         $assertion =
             $this->niceMock('Concise\Assertion')->disableConstructor()->expose(
-                    'performMatch'
-                )->stub(array('getMatcher' => $matcher))->get();
+                'performMatch'
+            )->stub(array('getMatcher' => $matcher))->get();
 
         $assertion->performMatch('? is between ? and ?', array(10, 0, 5));
     }

--- a/tests/Concise/AssertionTest.php
+++ b/tests/Concise/AssertionTest.php
@@ -3,11 +3,10 @@
 namespace Concise;
 
 use Concise\Matcher\Between;
-use Concise\Syntax\MatcherParser;
-use Concise\Matcher\True;
 use Concise\Matcher\False;
+use Concise\Matcher\True;
+use Concise\Syntax\MatcherParser;
 use PHPUnit_Framework_AssertionFailedError;
-use Symfony\Component\Config\Definition\Exception\Exception;
 
 class AssertionTest extends TestCase
 {
@@ -25,7 +24,11 @@ class AssertionTest extends TestCase
 
     public function testSettingDataWhenCreatingAssertion()
     {
-        $assertion = new Assertion('? equals ?', new Matcher\Equals(), array('abc', 'def'));
+        $assertion = new Assertion(
+            '? equals ?',
+            new Matcher\Equals(),
+            array('abc', 'def')
+        );
         $this->assert($assertion->getData(), equals, array('abc', 'def'));
     }
 
@@ -45,15 +48,20 @@ class AssertionTest extends TestCase
             'c' => 'xyz'
         );
         $assertion = new Assertion('a equals b', $matcher, $data);
-        $expected = "\n  a (integer) = 123\n  b (string) = \"abc\"\n  c (string) = \"xyz\"\n";
-        $this->assert((string) $assertion, equals, $expected);
+        $expected =
+            "\n  a (integer) = 123\n  b (string) = \"abc\"\n  c (string) = \"xyz\"\n";
+        $this->assert((string)$assertion, equals, $expected);
     }
 
     public function testCanSetDescriptiveString()
     {
         $assertion = new Assertion('? equals ?', new Matcher\Equals());
         $assertion->setDescription('my description');
-        $this->assert($assertion->getDescription(), equals, 'my description (? equals ?)');
+        $this->assert(
+            $assertion->getDescription(),
+            equals,
+            'my description (? equals ?)'
+        );
     }
 
     public function testDescriptionReturnsAssertionIfNotSet()
@@ -63,8 +71,8 @@ class AssertionTest extends TestCase
     }
 
     /**
-	 * @param string $theAssertion
-	 */
+     * @param string $theAssertion
+     */
     protected function compileAndRunAssertion($theAssertion)
     {
         $parser = MatcherParser::getInstance();
@@ -76,28 +84,32 @@ class AssertionTest extends TestCase
     protected function getStubForAssertionThatReturnsData(array $data)
     {
         return $this->niceMock('\Concise\Assertion', array('true', new True()))
-                    ->stub(array('getData' => $data))
-                    ->get();
+            ->stub(array('getData' => $data))
+            ->get();
     }
 
     public function testDoNotShowPHPUnitPropertiesOnError()
     {
-        $assertion = $this->getStubForAssertionThatReturnsData(self::getPHPUnitProperties());
-        $this->assert((string) $assertion, is_blank);
+        $assertion = $this->getStubForAssertionThatReturnsData(
+            self::getPHPUnitProperties()
+        );
+        $this->assert((string)$assertion, is_blank);
     }
 
     public function testDoNotShowDataSetOnError()
     {
-        $assertion = $this->getStubForAssertionThatReturnsData(array(
-            '__dataSet' => array()
-        ));
-        $this->assert((string) $assertion, is_blank);
+        $assertion = $this->getStubForAssertionThatReturnsData(
+            array(
+                '__dataSet' => array()
+            )
+        );
+        $this->assert((string)$assertion, is_blank);
     }
 
     public function testNoAttributesRendersAsAnEmptyString()
     {
         $assertion = $this->getStubForAssertionThatReturnsData(array());
-        $this->assert((string) $assertion, is_blank);
+        $this->assert((string)$assertion, is_blank);
     }
 
     public function testCanSetCustomFailureMessage()
@@ -140,7 +152,8 @@ class AssertionTest extends TestCase
     /**
      * @group #219
      */
-    public function testDidNotMatchExceptionIsConvertedIntoAssertionFailedError()
+    public function testDidNotMatchExceptionIsConvertedIntoAssertionFailedError(
+    )
     {
         $self = $this;
         $block = function () use ($self) {
@@ -152,7 +165,11 @@ class AssertionTest extends TestCase
 
             $assertion->performMatch('? is between ? and ?', array(10, 0, 5));
         };
-        $this->assert($block, throws, '\PHPUnit_Framework_AssertionFailedError');
+        $this->assert(
+            $block,
+            throws,
+            '\PHPUnit_Framework_AssertionFailedError'
+        );
     }
 
     /**
@@ -160,16 +177,17 @@ class AssertionTest extends TestCase
      * @expectedExceptionMessage foobar
      * @group #219
      */
-    public function testAnyOtherTypeOfExceptionIsNotConvertedToAssertionFailedError()
+    public function testAnyOtherTypeOfExceptionIsNotConvertedToAssertionFailedError(
+    )
     {
         $matcher = $this->mock('\Concise\Matcher\AbstractMatcher')
-            ->stub('match')->andThrow(new \Exception('foobar'))
+            ->stub('match')
+            ->andThrow(new \Exception('foobar'))
             ->get();
-        $assertion = $this->niceMock('Concise\Assertion')
-            ->disableConstructor()
-            ->expose('performMatch')
-            ->stub(array('getMatcher' => $matcher))
-            ->get();
+        $assertion =
+            $this->niceMock('Concise\Assertion')->disableConstructor()->expose(
+                    'performMatch'
+                )->stub(array('getMatcher' => $matcher))->get();
 
         $assertion->performMatch('? is between ? and ?', array(10, 0, 5));
     }

--- a/tests/Concise/Console/CommandColorSchemeTest.php
+++ b/tests/Concise/Console/CommandColorSchemeTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Console;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class CommandColorSchemeTest extends TestCase
 {
@@ -16,21 +16,30 @@ class CommandColorSchemeTest extends TestCase
 
     public function testDefaultColorSchemeIsSet()
     {
-        $this->assert($this->command->getColorScheme(), instance_of, 'Concise\Console\Theme\DefaultTheme');
+        $this->assert(
+            $this->command->getColorScheme(),
+            instance_of,
+            'Concise\Console\Theme\DefaultTheme'
+        );
     }
 
     public function testColorSchemeCanBeAClassName()
     {
         $theme = $this->mock('Concise\Console\Theme\DefaultTheme')->get();
         $this->setProperty($this->command, 'colorScheme', get_class($theme));
-        $this->assert(get_class($this->command->getColorScheme()), equals, get_class($theme));
+        $this->assert(
+            get_class($this->command->getColorScheme()),
+            equals,
+            get_class($theme)
+        );
     }
 
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage No such color scheme 'Foo\Bar'.
      */
-    public function testColorSchemeWillThrowExceptionIfColorSchemeClassDoesNotExist()
+    public function testColorSchemeWillThrowExceptionIfColorSchemeClassDoesNotExist(
+    )
     {
         $this->setProperty($this->command, 'colorScheme', 'Foo\Bar');
         $this->command->getColorScheme();
@@ -39,12 +48,20 @@ class CommandColorSchemeTest extends TestCase
     public function testColorSchemeCanBeAClassNameFoundInTheDefaultNamespace()
     {
         $this->setProperty($this->command, 'colorScheme', 'Default');
-        $this->assert($this->command->getColorScheme(), instance_of, 'Concise\Console\Theme\DefaultTheme');
+        $this->assert(
+            $this->command->getColorScheme(),
+            instance_of,
+            'Concise\Console\Theme\DefaultTheme'
+        );
     }
 
     public function testColorSchemeWithLowerCase()
     {
         $this->setProperty($this->command, 'colorScheme', 'default');
-        $this->assert($this->command->getColorScheme(), instance_of, 'Concise\Console\Theme\DefaultTheme');
+        $this->assert(
+            $this->command->getColorScheme(),
+            instance_of,
+            'Concise\Console\Theme\DefaultTheme'
+        );
     }
 }

--- a/tests/Concise/Console/CommandColorSchemeTest.php
+++ b/tests/Concise/Console/CommandColorSchemeTest.php
@@ -38,8 +38,7 @@ class CommandColorSchemeTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage No such color scheme 'Foo\Bar'.
      */
-    public function testColorSchemeWillThrowExceptionIfColorSchemeClassDoesNotExist(
-    )
+    public function testColorSchemeWillThrowExceptionIfColorSchemeClassDoesNotExist()
     {
         $this->setProperty($this->command, 'colorScheme', 'Foo\Bar');
         $this->command->getColorScheme();

--- a/tests/Concise/Console/CommandTest.php
+++ b/tests/Concise/Console/CommandTest.php
@@ -27,8 +27,8 @@ class CommandTest extends TestCase
     protected function getCommandMock()
     {
         return $this->niceMock('Concise\Console\CommandStub')->expose(
-                'createRunner'
-            )->get();
+            'createRunner'
+        )->get();
     }
 
     public function testCreateRunnerReturnsAConciseRunner()

--- a/tests/Concise/Console/CommandTest.php
+++ b/tests/Concise/Console/CommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Console;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class CommandStub extends Command
 {
@@ -26,41 +26,67 @@ class CommandTest extends TestCase
 
     protected function getCommandMock()
     {
-        return $this->niceMock('Concise\Console\CommandStub')
-                    ->expose('createRunner')
-                    ->get();
+        return $this->niceMock('Concise\Console\CommandStub')->expose(
+                'createRunner'
+            )->get();
     }
 
     public function testCreateRunnerReturnsAConciseRunner()
     {
         $command = $this->getCommandMock();
-        $this->assert($command->createRunner(), instance_of, 'Concise\Console\TestRunner\DefaultTestRunner');
+        $this->assert(
+            $command->createRunner(),
+            instance_of,
+            'Concise\Console\TestRunner\DefaultTestRunner'
+        );
     }
 
     public function testPrinterUsesProxy()
     {
         $command = $this->getCommandMock();
-        $this->assert($command->createRunner()->getPrinter(), instance_of, 'Concise\Console\ResultPrinter\ResultPrinterProxy');
+        $this->assert(
+            $command->createRunner()->getPrinter(),
+            instance_of,
+            'Concise\Console\ResultPrinter\ResultPrinterProxy'
+        );
     }
 
     public function testVerboseIsFalseByDefault()
     {
         $command = $this->getCommandMock();
-        $this->assert($command->createRunner()->getPrinter()->getResultPrinter()->isVerbose(), is_false);
+        $this->assert(
+            $command->createRunner()
+                ->getPrinter()
+                ->getResultPrinter()
+                ->isVerbose(),
+            is_false
+        );
     }
 
     public function testVerboseIsTurnedOnIfItExistsAndHasBeenSet()
     {
         $command = $this->getCommandMock();
         $command->setArgument('verbose', true);
-        $this->assert($command->createRunner()->getPrinter()->getResultPrinter()->isVerbose(), is_true);
+        $this->assert(
+            $command->createRunner()
+                ->getPrinter()
+                ->getResultPrinter()
+                ->isVerbose(),
+            is_true
+        );
     }
 
     public function testVerboseIsNotTurnedOnIfItExistsButIfNotTrue()
     {
         $command = $this->getCommandMock();
         $command->setArgument('verbose', false);
-        $this->assert($command->createRunner()->getPrinter()->getResultPrinter()->isVerbose(), is_false);
+        $this->assert(
+            $command->createRunner()
+                ->getPrinter()
+                ->getResultPrinter()
+                ->isVerbose(),
+            is_false
+        );
     }
 
     public function testCIResultPrinterIsUsedIfCIIsTrue()
@@ -68,7 +94,11 @@ class CommandTest extends TestCase
         $command = $this->getCommandMock();
         $command->setCI(true);
 
-        $this->assert($command->getResultPrinter(), instance_of, 'Concise\Console\ResultPrinter\CIResultPrinter');
+        $this->assert(
+            $command->getResultPrinter(),
+            instance_of,
+            'Concise\Console\ResultPrinter\CIResultPrinter'
+        );
     }
 
     public function testDefaultResultPrinterIsNotUsedIfCIIsFalse()
@@ -76,12 +106,20 @@ class CommandTest extends TestCase
         $command = $this->getCommandMock();
         $command->setCI(false);
 
-        $this->assert($command->getResultPrinter(), instance_of, 'Concise\Console\ResultPrinter\DefaultResultPrinter');
+        $this->assert(
+            $command->getResultPrinter(),
+            instance_of,
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        );
     }
 
     public function testDefaultResultPrinterIsUsedByDefault()
     {
         $command = $this->getCommandMock();
-        $this->assert($command->getResultPrinter(), instance_of, 'Concise\Console\ResultPrinter\DefaultResultPrinter');
+        $this->assert(
+            $command->getResultPrinter(),
+            instance_of,
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        );
     }
 }

--- a/tests/Concise/Console/ResultPrinter/AbstractResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/AbstractResultPrinterTest.php
@@ -9,22 +9,36 @@ class AbstractResultPrinterTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\AbstractResultPrinter')->get();
+        $this->resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\AbstractResultPrinter'
+        )->get();
     }
 
     public function testResultPrinterImplementsTestResultDelegateInterface()
     {
-        $this->assert($this->resultPrinter, instance_of, 'Concise\Console\TestRunner\TestResultDelegateInterface');
+        $this->assert(
+            $this->resultPrinter,
+            instance_of,
+            'Concise\Console\TestRunner\TestResultDelegateInterface'
+        );
     }
 
     public function testDefaultSuccessCountIsZero()
     {
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testDefaultFailureCountIsZero()
     {
-        $this->assert($this->resultPrinter->getFailureCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getFailureCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testDefaultErrorCountIsZero()
@@ -34,7 +48,11 @@ class AbstractResultPrinterTest extends TestCase
 
     public function testDefaultIncompleteCountIsZero()
     {
-        $this->assert($this->resultPrinter->getIncompleteCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getIncompleteCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testDefaultRiskyCountIsZero()
@@ -44,7 +62,11 @@ class AbstractResultPrinterTest extends TestCase
 
     public function testDefaultSkippedCountIsZero()
     {
-        $this->assert($this->resultPrinter->getSkippedCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getSkippedCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testDefaultTestCountIsZero()
@@ -54,64 +76,101 @@ class AbstractResultPrinterTest extends TestCase
 
     public function testDefaultTotalTestCountIsZero()
     {
-        $this->assert($this->resultPrinter->getTotalTestCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getTotalTestCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testDefaultAssertionCountIsZero()
     {
-        $this->assert($this->resultPrinter->getAssertionCount(), exactly_equals, 0);
+        $this->assert(
+            $this->resultPrinter->getAssertionCount(),
+            exactly_equals,
+            0
+        );
     }
 
     public function testSuccessCountIsTheTestCount()
     {
         $this->resultPrinter->testCount = 20;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 20);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            20
+        );
     }
 
     public function testSuccessCountWillNotIncludeSkipped()
     {
         $this->resultPrinter->testCount = 20;
         $this->resultPrinter->skippedCount = 10;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 10);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            10
+        );
     }
 
     public function testSuccessCountWillNotIncludeFailures()
     {
         $this->resultPrinter->testCount = 20;
         $this->resultPrinter->failureCount = 10;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 10);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            10
+        );
     }
 
     public function testSuccessCountWillNotIncludeErrors()
     {
         $this->resultPrinter->testCount = 20;
         $this->resultPrinter->errorCount = 10;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 10);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            10
+        );
     }
 
     public function testSuccessCountWillNotIncludeIncompleteTests()
     {
         $this->resultPrinter->testCount = 20;
         $this->resultPrinter->incompleteCount = 10;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 10);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            10
+        );
     }
 
     public function testSuccessCountWillNotIncludeRiskyTests()
     {
         $this->resultPrinter->testCount = 20;
         $this->resultPrinter->riskyCount = 10;
-        $this->assert($this->resultPrinter->getSuccessCount(), exactly_equals, 10);
+        $this->assert(
+            $this->resultPrinter->getSuccessCount(),
+            exactly_equals,
+            10
+        );
     }
 
     public function testEndTestReturnsNull()
     {
         $test = $this->mock('PHPUnit_Framework_Test')->get();
-        $this->assert($this->resultPrinter->endTest(0, $test, 0.0, null), is_null);
+        $this->assert(
+            $this->resultPrinter->endTest(0, $test, 0.0, null),
+            is_null
+        );
     }
 
     public function testEndTestSuiteReturnsNull()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->get();
         $this->assert($this->resultPrinter->endTestSuite($suite), is_null);
     }
 

--- a/tests/Concise/Console/ResultPrinter/CIResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/CIResultPrinterTest.php
@@ -8,19 +8,21 @@ class CIResultPrinterTest extends TestCase
 {
     public function testUpdateCallsWrite()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\CIResultPrinter')
-                              ->expect('write')
-                              ->get();
+        $resultPrinter =
+            $this->niceMock('Concise\Console\ResultPrinter\CIResultPrinter')
+                ->expect('write')
+                ->get();
         $resultPrinter->update();
     }
 
     public function testAppendTextAbovePrintsANewLineAbove()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\CIResultPrinter')
-                              ->expect('write')
-                              ->stub('update')
-                              ->stub('restoreCursor')
-                              ->get();
+        $resultPrinter =
+            $this->niceMock('Concise\Console\ResultPrinter\CIResultPrinter')
+                ->expect('write')
+                ->stub('update')
+                ->stub('restoreCursor')
+                ->get();
         $resultPrinter->appendTextAbove('a');
     }
 }

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterEndTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterEndTest.php
@@ -3,7 +3,6 @@
 namespace Concise\Console\ResultPrinter;
 
 use Concise\TestCase;
-use Concise\Console\Theme\DefaultTheme;
 use Exception;
 use PHPUnit_Runner_BaseTestRunner;
 
@@ -13,33 +12,49 @@ class DefaultResultPrinterEndTest extends TestCase
     {
         parent::setUp();
         $this->e = new Exception();
-        $this->test = $this->mock('PHPUnit_Framework_TestCase')
-                           ->stub('getName')
-                           ->get();
+        $this->test =
+            $this->mock('PHPUnit_Framework_TestCase')->stub('getName')->get();
     }
 
     protected function getTheme()
     {
-        return $this->mock('Concise\Console\Theme\DefaultTheme')
-                    ->stub(array('getTheme' => array(
-                        PHPUnit_Runner_BaseTestRunner::STATUS_PASSED     => 'success_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE    => 'failure_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_ERROR      => 'error_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED    => 'skipped_color',
+        return $this->mock('Concise\Console\Theme\DefaultTheme')->stub(
+                array(
+                    'getTheme' => array(
+                        PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => 'success_color',
+                        PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => 'failure_color',
+                        PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => 'error_color',
+                        PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => 'skipped_color',
                         PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => 'incomplete_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_RISKY      => 'risky_color',
-                    )))
-                    ->get();
+                        PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => 'risky_color',
+                    )
+                )
+            )->get();
     }
 
     public function endTestColorData()
     {
         return array(
-            'failure'    => array(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 'failure_color'),
-            'error'      => array(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR, 'error_color'),
-            'skipped'    => array(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, 'skipped_color'),
-            'incomplete' => array(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, 'incomplete_color'),
-            'risky'      => array(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY, 'risky_color'),
+            'failure' => array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                'failure_color'
+            ),
+            'error' => array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_ERROR,
+                'error_color'
+            ),
+            'skipped' => array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED,
+                'skipped_color'
+            ),
+            'incomplete' => array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE,
+                'incomplete_color'
+            ),
+            'risky' => array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_RISKY,
+                'risky_color'
+            ),
         );
     }
 
@@ -48,19 +63,28 @@ class DefaultResultPrinterEndTest extends TestCase
      */
     public function testEndTestWillCallAdd($status, $color)
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter', array($this->getTheme()))
-                              ->expects('add')->with($status, $this->test, $this->e)
-                              ->stub('update')
-                              ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter',
+            array($this->getTheme())
+        )
+            ->expects('add')
+            ->with($status, $this->test, $this->e)
+            ->stub('update')
+            ->get();
         $resultPrinter->endTest($status, $this->test, 1.23, $this->e);
     }
 
     public function testEndTestWithUnknownStatusWillNotCallAdd()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter', array($this->getTheme()))
-                              ->expects('add')->never()
-                              ->stub('update')
-                              ->get();
-        $resultPrinter->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $this->test, 1.23, $this->e);
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter',
+            array($this->getTheme())
+        )->expects('add')->never()->stub('update')->get();
+        $resultPrinter->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+            $this->test,
+            1.23,
+            $this->e
+        );
     }
 }

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterEndTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterEndTest.php
@@ -19,17 +19,17 @@ class DefaultResultPrinterEndTest extends TestCase
     protected function getTheme()
     {
         return $this->mock('Concise\Console\Theme\DefaultTheme')->stub(
-                array(
-                    'getTheme' => array(
-                        PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => 'success_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => 'failure_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => 'error_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => 'skipped_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => 'incomplete_color',
-                        PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => 'risky_color',
-                    )
+            array(
+                'getTheme' => array(
+                    PHPUnit_Runner_BaseTestRunner::STATUS_PASSED => 'success_color',
+                    PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE => 'failure_color',
+                    PHPUnit_Runner_BaseTestRunner::STATUS_ERROR => 'error_color',
+                    PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED => 'skipped_color',
+                    PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => 'incomplete_color',
+                    PHPUnit_Runner_BaseTestRunner::STATUS_RISKY => 'risky_color',
                 )
-            )->get();
+            )
+        )->get();
     }
 
     public function endTestColorData()

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
@@ -4,8 +4,8 @@ namespace Concise\Console\ResultPrinter;
 
 use Concise\Mock\Invocation;
 use Concise\TestCase;
-use PHPUnit_Runner_BaseTestRunner;
 use Exception;
+use PHPUnit_Runner_BaseTestRunner;
 
 class DefaultResultPrinterStub extends DefaultResultPrinter
 {
@@ -41,7 +41,11 @@ class DefaultResultPrinterTest extends TestCase
 
     public function testWillGetConsoleWidthOnStartup()
     {
-        $this->assert($this->resultPrinter->getWidth(), equals, exec('tput cols'));
+        $this->assert(
+            $this->resultPrinter->getWidth(),
+            equals,
+            exec('tput cols')
+        );
     }
 
     public function testFirstIssueNumberIsOne()
@@ -51,61 +55,73 @@ class DefaultResultPrinterTest extends TestCase
 
     public function testEndTestWillIncrementIssueNumber()
     {
-        $test = $this->mock('PHPUnit_Framework_TestCase')
-                     ->stub(array('getName' => ''))
-                     ->get();
+        $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getName' => '')
+            )->get();
         $exception = $this->mock('Exception')->get();
-        $this->resultPrinter->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, $test, 0, $exception);
+        $this->resultPrinter->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+            $test,
+            0,
+            $exception
+        );
         $this->assert($this->resultPrinter->getIssueNumber(), equals, 2);
     }
 
     public function testEndTestWillNotIncrementIssueNumberOnSuccess()
     {
-        $test = $this->mock('PHPUnit_Framework_TestCase')
-                     ->stub(array('getName' => ''))
-                     ->get();
-        $this->resultPrinter->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $test, 0, null);
+        $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getName' => '')
+            )->get();
+        $this->resultPrinter->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+            $test,
+            0,
+            null
+        );
         $this->assert($this->resultPrinter->getIssueNumber(), equals, 1);
     }
 
     public function testEndTestWillUpdateProgress()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expects('update')
-                              ->get();
-        $test = $this->mock('PHPUnit_Framework_TestCase')
-                     ->stub(array('getName' => ''))
-                     ->get();
-        $resultPrinter->endTest(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $test, 0, null);
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expects('update')->get();
+        $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getName' => '')
+            )->get();
+        $resultPrinter->endTest(
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+            $test,
+            0,
+            null
+        );
     }
 
     public function testUpdateWillPrintProgress()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expose('update')
-                              ->expect('write')
-                              ->stub('restoreCursor')
-                              ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('update')->expect('write')->stub('restoreCursor')->get();
         $resultPrinter->update();
     }
 
     public function testStartSuiteWillUpdateProgress()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expects('update')
-                              ->get();
-        $suite = $this->niceMock('PHPUnit_Framework_TestSuite')
-                      ->stub(array('getName' => ''))
-                      ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expects('update')->get();
+        $suite = $this->niceMock('PHPUnit_Framework_TestSuite')->stub(
+                array('getName' => '')
+            )->get();
         $resultPrinter->startTestSuite($suite);
     }
 
     public function testEndWillUpdateProgress()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expects('update')
-                              ->stub('write')
-                              ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expects('update')->stub('write')->get();
         $resultPrinter->end();
     }
 
@@ -115,16 +131,24 @@ class DefaultResultPrinterTest extends TestCase
         $hide = 0;
 
         return array(
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED,    true,  $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED,    false, $hide),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, true,  $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, false, $hide),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,    true,  $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,    false, $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR,      true,  $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR,      false, $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY,      true,  $show),
-            array(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY,      false, $hide),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, true, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, false, $hide),
+            array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE,
+                true,
+                $show
+            ),
+            array(
+                PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE,
+                false,
+                $hide
+            ),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, true, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, false, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR, true, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR, false, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY, true, $show),
+            array(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY, false, $hide),
         );
     }
 
@@ -133,148 +157,196 @@ class DefaultResultPrinterTest extends TestCase
      */
     public function testVerbosePrintsIssues($status, $isVerbose, $willBePrinted)
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expect('appendTextAbove')->exactly($willBePrinted)
-                              ->expose('add')
-                              ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )
+            ->expect('appendTextAbove')
+            ->exactly($willBePrinted)
+            ->expose('add')
+            ->get();
         $resultPrinter->setVerbose($isVerbose);
-        $test = $this->niceMock('PHPUnit_Framework_TestCase')
-                     ->stub(array('getName' => ''))
-                     ->get();
+        $test = $this->niceMock('PHPUnit_Framework_TestCase')->stub(
+                array('getName' => '')
+            )->get();
         $resultPrinter->add($status, $test, new Exception());
     }
 
     public function testStartTimeIsNow()
     {
-        $this->assert($this->getProperty($this->resultPrinter, 'startTime'), equals, time(), within, 1);
+        $this->assert(
+            $this->getProperty($this->resultPrinter, 'startTime'),
+            equals,
+            time(),
+            within,
+            1
+        );
     }
 
     public function testAssertionStringIncludesTheRunTime()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->get();
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, '0 seconds');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            '0 seconds'
+        );
     }
 
     public function testWillPrintCorrectTimeElapsed()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 10);
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, '10 seconds');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            '10 seconds'
+        );
     }
 
     public function testUsesTimeFormatter()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 200);
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, '3 minutes 20 seconds');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            '3 minutes 20 seconds'
+        );
     }
 
     public function testHasUpdatedIsFalseByDefault()
     {
-        $this->assert($this->getProperty($this->resultPrinter, 'hasUpdated'), is_false);
+        $this->assert(
+            $this->getProperty($this->resultPrinter, 'hasUpdated'),
+            is_false
+        );
     }
 
     public function testHasUpdatedIsTrueAfterUpdateIsCalled()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->stub('write')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->get();
         $resultPrinter->update();
-        $this->assert($this->getProperty($resultPrinter, 'hasUpdated'), is_true);
+        $this->assert(
+            $this->getProperty($resultPrinter, 'hasUpdated'),
+            is_true
+        );
     }
 
     public function testWillRestoreCursorWithUpdate()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->stub('write')
-            ->expect('restoreCursor')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->expect('restoreCursor')->get();
         $resultPrinter->update();
         $resultPrinter->update();
     }
 
     public function testWillNotRestoreCursorWithFirstUpdate()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->stub('write')
-            ->expect('restoreCursor')->never()
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->expect('restoreCursor')->never()->get();
         $resultPrinter->update();
     }
 
     public function testAppendTextAboveMustRestoreTheCursorAlways()
     {
         /** @var $resultPrinter \Concise\Console\ResultPrinter\DefaultResultPrinter */
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->stub('write')
-            ->stub('update')
-            ->expect('restoreCursor')
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->stub('update')->expect('restoreCursor')->get();
         $resultPrinter->appendTextAbove('');
     }
 
     public function testWillShowEstimate()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 25)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, ' remaining');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            ' remaining'
+        );
     }
 
     public function testWillShowAccurateEstimate()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 25)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, ' (3 minutes remaining)');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            ' (3 minutes remaining)'
+        );
     }
 
     public function testWillNotShowEstimateIfETAIsZero()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 100))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 100)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
-        $this->assert($resultPrinter->getAssertionString(), does_not_contain_string, ' remaining');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            does_not_contain_string,
+            ' remaining'
+        );
     }
 
     public function testWillNotShowEstimateUntil5SecondsHaveElapsed()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 25)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 3);
 
-        $this->assert($resultPrinter->getAssertionString(), does_not_contain_string, ' remaining');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            does_not_contain_string,
+            ' remaining'
+        );
     }
 
     public function testWillShowEstimateOnce5SecondsHaveElapsed()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getAssertionString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getAssertionString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 25)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 5);
 
-        $this->assert($resultPrinter->getAssertionString(), contains_string, ' remaining');
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            contains_string,
+            ' remaining'
+        );
     }
 
     /**
@@ -283,10 +355,11 @@ class DefaultResultPrinterTest extends TestCase
     public function testWillNotRefreshEstimatedTimeMoreThanOncePerSecond()
     {
 
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getRemainingTimeString')
-            ->stub(array('getTotalTestCount' => 100, 'getTestCount' => 25))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getRemainingTimeString')->stub(
+                array('getTotalTestCount' => 100, 'getTestCount' => 25)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 5);
         $a = $resultPrinter->getRemainingTimeString();
         $this->setProperty($resultPrinter, 'startTime', time() - 10);
@@ -300,10 +373,11 @@ class DefaultResultPrinterTest extends TestCase
      */
     public function testCanOutputShortenedAssertionString()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-            ->expose('getRealAssertionString')
-            ->stub(array('getTotalTestCount' => 1000, 'getTestCount' => 200))
-            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expose('getRealAssertionString')->stub(
+                array('getTotalTestCount' => 1000, 'getTestCount' => 200)
+            )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 4000);
         $this->setProperty($resultPrinter, 'width', 80);
 
@@ -316,11 +390,16 @@ class DefaultResultPrinterTest extends TestCase
      */
     public function testWillUseShorterAssertionStringIfRequired()
     {
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )
             ->expose('getAssertionString')
-            ->stub('getRealAssertionString')->andReturnCallback(function (Invocation $invocation) {
-                return $invocation->getArgument(0) ? 'foo' : '';
-            })
+            ->stub('getRealAssertionString')
+            ->andReturnCallback(
+                function (Invocation $invocation) {
+                    return $invocation->getArgument(0) ? 'foo' : '';
+                }
+            )
             ->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 4000);
         $this->setProperty($resultPrinter, 'width', 80);

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
@@ -56,8 +56,8 @@ class DefaultResultPrinterTest extends TestCase
     public function testEndTestWillIncrementIssueNumber()
     {
         $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getName' => '')
-            )->get();
+            array('getName' => '')
+        )->get();
         $exception = $this->mock('Exception')->get();
         $this->resultPrinter->endTest(
             PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
@@ -71,8 +71,8 @@ class DefaultResultPrinterTest extends TestCase
     public function testEndTestWillNotIncrementIssueNumberOnSuccess()
     {
         $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getName' => '')
-            )->get();
+            array('getName' => '')
+        )->get();
         $this->resultPrinter->endTest(
             PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
             $test,
@@ -88,8 +88,8 @@ class DefaultResultPrinterTest extends TestCase
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expects('update')->get();
         $test = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getName' => '')
-            )->get();
+            array('getName' => '')
+        )->get();
         $resultPrinter->endTest(
             PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
             $test,
@@ -112,8 +112,8 @@ class DefaultResultPrinterTest extends TestCase
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expects('update')->get();
         $suite = $this->niceMock('PHPUnit_Framework_TestSuite')->stub(
-                array('getName' => '')
-            )->get();
+            array('getName' => '')
+        )->get();
         $resultPrinter->startTestSuite($suite);
     }
 
@@ -166,8 +166,8 @@ class DefaultResultPrinterTest extends TestCase
             ->get();
         $resultPrinter->setVerbose($isVerbose);
         $test = $this->niceMock('PHPUnit_Framework_TestCase')->stub(
-                array('getName' => '')
-            )->get();
+            array('getName' => '')
+        )->get();
         $resultPrinter->add($status, $test, new Exception());
     }
 
@@ -274,8 +274,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getAssertionString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 25)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 25)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
         $this->assert(
@@ -290,8 +290,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getAssertionString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 25)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 25)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
         $this->assert(
@@ -306,8 +306,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getAssertionString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 100)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 100)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 60);
 
         $this->assert(
@@ -322,8 +322,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getAssertionString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 25)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 25)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 3);
 
         $this->assert(
@@ -338,8 +338,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getAssertionString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 25)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 25)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 5);
 
         $this->assert(
@@ -358,8 +358,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getRemainingTimeString')->stub(
-                array('getTotalTestCount' => 100, 'getTestCount' => 25)
-            )->get();
+            array('getTotalTestCount' => 100, 'getTestCount' => 25)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 5);
         $a = $resultPrinter->getRemainingTimeString();
         $this->setProperty($resultPrinter, 'startTime', time() - 10);
@@ -376,8 +376,8 @@ class DefaultResultPrinterTest extends TestCase
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expose('getRealAssertionString')->stub(
-                array('getTotalTestCount' => 1000, 'getTestCount' => 200)
-            )->get();
+            array('getTotalTestCount' => 1000, 'getTestCount' => 200)
+        )->get();
         $this->setProperty($resultPrinter, 'startTime', time() - 4000);
         $this->setProperty($resultPrinter, 'width', 80);
 

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyDelegateTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyDelegateTest.php
@@ -66,12 +66,11 @@ class ResultPrinterProxyDelegateTest extends TestCase
         );
     }
 
-    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingTestCase(
-    )
+    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingTestCase()
     {
         $testCase = $this->mock('PHPUnit_Framework_TestCase')->expect(
-                'getNumAssertions'
-            )->andReturn(123)->get();
+            'getNumAssertions'
+        )->andReturn(123)->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
         $this->assert(
@@ -81,8 +80,7 @@ class ResultPrinterProxyDelegateTest extends TestCase
         );
     }
 
-    public function testEndTestWillIncrementAssertionsByOneMultipleTimesIfLegacyPhptIsUsed(
-    )
+    public function testEndTestWillIncrementAssertionsByOneMultipleTimesIfLegacyPhptIsUsed()
     {
         $testCase = $this->mock('PHPUnit_Extensions_PhptTestCase')
             ->disableConstructor()
@@ -97,12 +95,11 @@ class ResultPrinterProxyDelegateTest extends TestCase
         );
     }
 
-    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingMultipleTestCases(
-    )
+    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingMultipleTestCases()
     {
         $testCase = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getNumAssertions' => 123)
-            )->get();
+            array('getNumAssertions' => 123)
+        )->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
         $proxy->endTest($testCase, 0);
@@ -214,15 +211,15 @@ class ResultPrinterProxyDelegateTest extends TestCase
     public function testProxyWillCallAddSuccess()
     {
         $testCase = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getNumAssertions' => 1)
-            )->get();
+            array('getNumAssertions' => 1)
+        )->get();
         $resultPrinter = $this->niceMock(
             'Concise\Console\ResultPrinter\DefaultResultPrinter'
         )->expect('endTest')->with(
-                PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
-                $testCase,
-                0.1
-            )->get();
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+            $testCase,
+            0.1
+        )->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->endTest($testCase, 0.1);
     }

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyDelegateTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyDelegateTest.php
@@ -15,103 +15,141 @@ class ResultPrinterProxyDelegateTest extends TestCase
 
     public function testStartTestSuiteWillCallResultPrinter()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                              ->stub(array('count' => 0))
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('count' => 0))
+            ->get();
 
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('startTestSuite')->with($suite)
-                              ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('startTestSuite')
+                ->with($suite)
+                ->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
     }
 
     public function testWillSetTotalTestCountWhenTheSuiteBegins()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                      ->expect('count')->andReturn(123)
-                      ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->expect('count')
+            ->andReturn(123)
+            ->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->startTestSuite($suite);
-        $this->assert($proxy->getResultPrinter()->getTotalTestCount(), equals, 123);
+        $this->assert(
+            $proxy->getResultPrinter()->getTotalTestCount(),
+            equals,
+            123
+        );
     }
 
     protected function getMuteResultPrinter()
     {
-        return $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                    ->stub('write')
-                    ->get();
+        return $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->get();
     }
 
     public function testEndTestWillIncrementAssertionsByOneIfLegacyPhptIsUsed()
     {
-        $testCase = $this->mock('PHPUnit_Extensions_PhptTestCase')->disableConstructor()
-                         ->get();
+        $testCase = $this->mock('PHPUnit_Extensions_PhptTestCase')
+            ->disableConstructor()
+            ->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
-        $this->assert($proxy->getResultPrinter()->getAssertionCount(), equals, 1);
+        $this->assert(
+            $proxy->getResultPrinter()->getAssertionCount(),
+            equals,
+            1
+        );
     }
 
-    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingTestCase()
+    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingTestCase(
+    )
     {
-        $testCase = $this->mock('PHPUnit_Framework_TestCase')
-                         ->expect('getNumAssertions')->andReturn(123)
-                         ->get();
+        $testCase = $this->mock('PHPUnit_Framework_TestCase')->expect(
+                'getNumAssertions'
+            )->andReturn(123)->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
-        $this->assert($proxy->getResultPrinter()->getAssertionCount(), equals, 123);
+        $this->assert(
+            $proxy->getResultPrinter()->getAssertionCount(),
+            equals,
+            123
+        );
     }
 
-    public function testEndTestWillIncrementAssertionsByOneMultipleTimesIfLegacyPhptIsUsed()
+    public function testEndTestWillIncrementAssertionsByOneMultipleTimesIfLegacyPhptIsUsed(
+    )
     {
-        $testCase = $this->mock('PHPUnit_Extensions_PhptTestCase')->disableConstructor()
-                         ->get();
+        $testCase = $this->mock('PHPUnit_Extensions_PhptTestCase')
+            ->disableConstructor()
+            ->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
         $proxy->endTest($testCase, 0);
-        $this->assert($proxy->getResultPrinter()->getAssertionCount(), equals, 2);
+        $this->assert(
+            $proxy->getResultPrinter()->getAssertionCount(),
+            equals,
+            2
+        );
     }
 
-    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingMultipleTestCases()
+    public function testEndTestWillIncrementAssertionsRealAmountWhenUsingMultipleTestCases(
+    )
     {
-        $testCase = $this->mock('PHPUnit_Framework_TestCase')
-                         ->stub(array('getNumAssertions' => 123))
-                         ->get();
+        $testCase = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getNumAssertions' => 123)
+            )->get();
         $proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
         $proxy->endTest($testCase, 0);
         $proxy->endTest($testCase, 0);
-        $this->assert($proxy->getResultPrinter()->getAssertionCount(), equals, 246);
+        $this->assert(
+            $proxy->getResultPrinter()->getAssertionCount(),
+            equals,
+            246
+        );
     }
 
     public function testWillNotUpdateTheTotalTestIfMultipleTestSuitesStart()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                      ->stub('count')->andReturn(123, 456)
-                      ->get();
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->stub('startTestSuite')
-                              ->stub('endTestSuite')
-                              ->stub('end')
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub('count')
+            ->andReturn(123, 456)
+            ->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('startTestSuite')->stub('endTestSuite')->stub('end')->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
         $proxy->startTestSuite($suite);
         $proxy->endTestSuite($suite);
         $proxy->endTestSuite($suite);
-        $this->assert($proxy->getResultPrinter()->getTotalTestCount(), equals, 123);
+        $this->assert(
+            $proxy->getResultPrinter()->getTotalTestCount(),
+            equals,
+            123
+        );
     }
 
     public function testStartTestSuiteWillCallResultPrinterMultipleTimes()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                              ->stub(array('count' => 0))
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('count' => 0))
+            ->get();
 
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('startTestSuite')->with($suite)->twice()
-                              ->stub('endTestSuite')
-                              ->stub('end')
-                              ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('startTestSuite')
+                ->with($suite)
+                ->twice()
+                ->stub('endTestSuite')
+                ->stub('end')
+                ->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
         $proxy->startTestSuite($suite);
@@ -121,14 +159,16 @@ class ResultPrinterProxyDelegateTest extends TestCase
 
     public function testFinishWillBeCalledWithEndTestSuite()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                      ->stub(array('count' => 0))
-                      ->get();
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('end')
-                              ->stub('startTestSuite')
-                              ->stub('endTestSuite')
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('count' => 0))
+            ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('end')
+                ->stub('startTestSuite')
+                ->stub('endTestSuite')
+                ->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
         $proxy->endTestSuite($suite);
@@ -136,14 +176,17 @@ class ResultPrinterProxyDelegateTest extends TestCase
 
     public function testEndTestSuiteWillBeCalledInResultPrinter()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                      ->stub(array('count' => 0))
-                      ->get();
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('endTestSuite')->with($suite)
-                              ->stub('end')
-                              ->stub('startTestSuite')
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('count' => 0))
+            ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('endTestSuite')
+                ->with($suite)
+                ->stub('end')
+                ->stub('startTestSuite')
+                ->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
         $proxy->endTestSuite($suite);
@@ -151,14 +194,16 @@ class ResultPrinterProxyDelegateTest extends TestCase
 
     public function testFinishWillBeOnlyBeCalledOnce()
     {
-        $suite = $this->mock('PHPUnit_Framework_TestSuite')->disableConstructor()
-                      ->stub(array('count' => 0))
-                      ->get();
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('end')
-                              ->stub('startTestSuite')
-                              ->stub('endTestSuite')
-                              ->get();
+        $suite = $this->mock('PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('count' => 0))
+            ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('end')
+                ->stub('startTestSuite')
+                ->stub('endTestSuite')
+                ->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->startTestSuite($suite);
         $proxy->startTestSuite($suite);
@@ -168,12 +213,16 @@ class ResultPrinterProxyDelegateTest extends TestCase
 
     public function testProxyWillCallAddSuccess()
     {
-        $testCase = $this->mock('PHPUnit_Framework_TestCase')
-                         ->stub(array('getNumAssertions' => 1))
-                         ->get();
-        $resultPrinter = $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                              ->expect('endTest')->with(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $testCase, 0.1)
-                              ->get();
+        $testCase = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getNumAssertions' => 1)
+            )->get();
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->expect('endTest')->with(
+                PHPUnit_Runner_BaseTestRunner::STATUS_PASSED,
+                $testCase,
+                0.1
+            )->get();
         $proxy = new ResultPrinterProxy($resultPrinter);
         $proxy->endTest($testCase, 0.1);
     }

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyStatisticsTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyStatisticsTest.php
@@ -3,7 +3,6 @@
 namespace Concise\Console\ResultPrinter;
 
 use Concise\TestCase;
-use Exception;
 
 class ResultPrinterProxyStatisticsTest extends TestCase
 {
@@ -17,47 +16,66 @@ class ResultPrinterProxyStatisticsTest extends TestCase
     {
         parent::setUp();
         $this->proxy = new ResultPrinterProxy($this->getMuteResultPrinter());
-        $this->test = $this->mock('PHPUnit_Framework_TestCase')
-                           ->stub('getName')
-                           ->get();
+        $this->test =
+            $this->mock('PHPUnit_Framework_TestCase')->stub('getName')->get();
         $this->e = $this->mock('Exception')->get();
     }
 
     protected function getMuteResultPrinter()
     {
-        return $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                    ->stub('write')
-                    ->get();
+        return $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->get();
     }
 
     public function testAddFailureWillIncrementCount()
     {
         $this->e = $this->mock('PHPUnit_Framework_AssertionFailedError')->get();
         $this->proxy->addFailure($this->test, $this->e, 0);
-        $this->assert($this->proxy->getResultPrinter()->getFailureCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getFailureCount(),
+            equals,
+            1
+        );
     }
 
     public function testAddErrorWillIncrementCount()
     {
         $this->proxy->addError($this->test, $this->e, 0);
-        $this->assert($this->proxy->getResultPrinter()->getErrorCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getErrorCount(),
+            equals,
+            1
+        );
     }
 
     public function testAddIncompleteWillIncrementCount()
     {
         $this->proxy->addIncompleteTest($this->test, $this->e, 0);
-        $this->assert($this->proxy->getResultPrinter()->getIncompleteCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getIncompleteCount(),
+            equals,
+            1
+        );
     }
 
     public function testAddSkippedWillIncrementCount()
     {
         $this->proxy->addSkippedTest($this->test, $this->e, 0);
-        $this->assert($this->proxy->getResultPrinter()->getSkippedCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getSkippedCount(),
+            equals,
+            1
+        );
     }
 
     public function testAddRiskyWillIncrementCount()
     {
         $this->proxy->addRiskyTest($this->test, $this->e, 0);
-        $this->assert($this->proxy->getResultPrinter()->getRiskyCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getRiskyCount(),
+            equals,
+            1
+        );
     }
 }

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTest.php
@@ -16,19 +16,27 @@ class ResultPrinterProxyTest extends TestCase
 
     protected function getMuteResultPrinter()
     {
-        return $this->niceMock('Concise\Console\ResultPrinter\DefaultResultPrinter')
-                    ->stub('write')
-                    ->get();
+        return $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )->stub('write')->get();
     }
 
     public function testProxyExtendsPHPUnit()
     {
-        $this->assert($this->proxy, instance_of, 'PHPUnit_TextUI_ResultPrinter');
+        $this->assert(
+            $this->proxy,
+            instance_of,
+            'PHPUnit_TextUI_ResultPrinter'
+        );
     }
 
     public function testGetResultPrinterReturnsAResultPrinterInterface()
     {
-        $this->assert($this->proxy->getResultPrinter(), instance_of, 'Concise\Console\TestRunner\TestResultDelegateInterface');
+        $this->assert(
+            $this->proxy->getResultPrinter(),
+            instance_of,
+            'Concise\Console\TestRunner\TestResultDelegateInterface'
+        );
     }
 
     public function testResultPrinterIsSetViaConstructor()
@@ -42,40 +50,50 @@ class ResultPrinterProxyTest extends TestCase
     {
         $test = $this->mock('PHPUnit_Framework_Test')->get();
         $this->proxy->endTest($test, 0.1);
-        $this->assert($this->proxy->getResultPrinter()->getTestCount(), equals, 1);
+        $this->assert(
+            $this->proxy->getResultPrinter()->getTestCount(),
+            equals,
+            1
+        );
     }
 
     public function testPrintHeaderReturnsNull()
     {
-        $proxy = $this->niceMock('Concise\Console\ResultPrinter\ResultPrinterProxy', array($this->getMuteResultPrinter()))
-                      ->expose('printHeader')
-                      ->get();
+        $proxy = $this->niceMock(
+            'Concise\Console\ResultPrinter\ResultPrinterProxy',
+            array($this->getMuteResultPrinter())
+        )->expose('printHeader')->get();
         $this->assert($proxy->printHeader(), is_null);
     }
 
     public function testPrintDefectsReturnsNull()
     {
-        $proxy = $this->niceMock('Concise\Console\ResultPrinter\ResultPrinterProxy', array($this->getMuteResultPrinter()))
-                      ->expose('printDefects')
-                      ->get();
+        $proxy = $this->niceMock(
+            'Concise\Console\ResultPrinter\ResultPrinterProxy',
+            array($this->getMuteResultPrinter())
+        )->expose('printDefects')->get();
         $this->assert($proxy->printDefects(array(), null), is_null);
     }
 
     public function testPrintDefectReturnsNull()
     {
-        $failure = $this->mock('PHPUnit_Framework_TestFailure')->disableConstructor()->get();
-        $proxy = $this->niceMock('Concise\Console\ResultPrinter\ResultPrinterProxy', array($this->getMuteResultPrinter()))
-                      ->expose('printDefect')
-                      ->get();
+        $failure = $this->mock('PHPUnit_Framework_TestFailure')
+            ->disableConstructor()
+            ->get();
+        $proxy = $this->niceMock(
+            'Concise\Console\ResultPrinter\ResultPrinterProxy',
+            array($this->getMuteResultPrinter())
+        )->expose('printDefect')->get();
         $this->assert($proxy->printDefect($failure, 0), is_null);
     }
 
     public function testPrintFooterReturnsNull()
     {
         $result = $this->mock('PHPUnit_Framework_TestResult')->get();
-        $proxy = $this->niceMock('Concise\Console\ResultPrinter\ResultPrinterProxy', array($this->getMuteResultPrinter()))
-                      ->expose('printFooter')
-                      ->get();
+        $proxy = $this->niceMock(
+            'Concise\Console\ResultPrinter\ResultPrinterProxy',
+            array($this->getMuteResultPrinter())
+        )->expose('printFooter')->get();
         $this->assert($proxy->printFooter($result), is_null);
     }
 
@@ -87,9 +105,10 @@ class ResultPrinterProxyTest extends TestCase
     public function testPrintResultReturnsNull()
     {
         $result = $this->mock('PHPUnit_Framework_TestResult')->get();
-        $proxy = $this->niceMock('Concise\Console\ResultPrinter\ResultPrinterProxy', array($this->getMuteResultPrinter()))
-                      ->expose('printResult')
-                      ->get();
+        $proxy = $this->niceMock(
+            'Concise\Console\ResultPrinter\ResultPrinterProxy',
+            array($this->getMuteResultPrinter())
+        )->expose('printResult')->get();
         $this->assert($proxy->printResult($result), is_null);
     }
 }

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTestDelegateTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTestDelegateTest.php
@@ -3,7 +3,6 @@
 namespace Concise\Console\ResultPrinter;
 
 use Concise\TestCase;
-use Exception;
 use PHPUnit_Runner_BaseTestRunner;
 
 class ResultPrinterProxyTestDelegateTest extends TestCase
@@ -17,9 +16,11 @@ class ResultPrinterProxyTestDelegateTest extends TestCase
 
     protected function getProxyThatExpectsStatus($expectedStatus)
     {
-        $resultPrinter = $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
-                              ->expect('endTest')->with($expectedStatus, $this->test, 0.1, $this->e)
-                              ->get();
+        $resultPrinter =
+            $this->mock('Concise\Console\ResultPrinter\AbstractResultPrinter')
+                ->expect('endTest')
+                ->with($expectedStatus, $this->test, 0.1, $this->e)
+                ->get();
 
         return new ResultPrinterProxy($resultPrinter);
     }
@@ -27,31 +28,41 @@ class ResultPrinterProxyTestDelegateTest extends TestCase
     public function testAddFailureWillCallResultPrinter()
     {
         $this->e = $this->mock('PHPUnit_Framework_AssertionFailedError')->get();
-        $proxy = $this->getProxyThatExpectsStatus(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE);
+        $proxy = $this->getProxyThatExpectsStatus(
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE
+        );
         $proxy->addFailure($this->test, $this->e, 0.1);
     }
 
     public function testAddErrorWillCallResultPrinter()
     {
-        $proxy = $this->getProxyThatExpectsStatus(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR);
+        $proxy = $this->getProxyThatExpectsStatus(
+            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR
+        );
         $proxy->addError($this->test, $this->e, 0.1);
     }
 
     public function testAddIncompleteWillCallResultPrinter()
     {
-        $proxy = $this->getProxyThatExpectsStatus(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE);
+        $proxy = $this->getProxyThatExpectsStatus(
+            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE
+        );
         $proxy->addIncompleteTest($this->test, $this->e, 0.1);
     }
 
     public function testAddSkippedWillCallResultPrinter()
     {
-        $proxy = $this->getProxyThatExpectsStatus(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED);
+        $proxy = $this->getProxyThatExpectsStatus(
+            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED
+        );
         $proxy->addSkippedTest($this->test, $this->e, 0.1);
     }
 
     public function testAddRiskyWillCallResultPrinter()
     {
-        $proxy = $this->getProxyThatExpectsStatus(PHPUnit_Runner_BaseTestRunner::STATUS_RISKY);
+        $proxy = $this->getProxyThatExpectsStatus(
+            PHPUnit_Runner_BaseTestRunner::STATUS_RISKY
+        );
         $proxy->addRiskyTest($this->test, $this->e, 0.1);
     }
 }

--- a/tests/Concise/Console/ResultPrinter/Utilities/FilePathSimplifierTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/FilePathSimplifierTest.php
@@ -15,7 +15,11 @@ class FilePathSimplifierTest extends TestCase
     public function testWillCropOffCurrentWorkingDirectory()
     {
         $simplifier = new FilePathSimplifier();
-        $this->assert($simplifier->process(getcwd() . '/foo/bar'), equals, 'foo/bar');
+        $this->assert(
+            $simplifier->process(getcwd() . '/foo/bar'),
+            equals,
+            'foo/bar'
+        );
     }
 
     /**

--- a/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTest.php
@@ -14,73 +14,125 @@ class ProgressBarTest extends ProgressBarTestCase
 
     public function testOneColorFillUpEntireBar()
     {
-        $result = $this->progressBar->render(5, array(
-            'green' => 5,
-        ));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'green' => 5,
+            )
+        );
         $this->assert($result, equals, $this->color(5, 'green'));
     }
 
     public function testTwoColors()
     {
-        $result = $this->progressBar->render(6, array(
-            'green' => 3,
-            'red'   => 3,
-        ));
-        $this->assert($result, equals, $this->color(3, 'green') . $this->color(3, 'red'));
+        $result = $this->progressBar->render(
+            6,
+            array(
+                'green' => 3,
+                'red' => 3,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(3, 'green') . $this->color(3, 'red')
+        );
     }
 
     public function testPartsMustBeProportionalToTheTotal()
     {
-        $result = $this->progressBar->render(5, array(
-            'green' => 60,
-            'red'   => 40,
-        ));
-        $this->assert($result, equals, $this->color(3, 'green') . $this->color(2, 'red'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'green' => 60,
+                'red' => 40,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(3, 'green') . $this->color(2, 'red')
+        );
     }
 
     public function testPartsAreNotAlwaysCleanlyDivisible()
     {
-        $result = $this->progressBar->render(5, array(
-            'green' => 4,
-            'red'   => 7,
-        ));
-        $this->assert($result, equals, $this->color(1, 'green') . $this->color(4, 'red'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'green' => 4,
+                'red' => 7,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(1, 'green') . $this->color(4, 'red')
+        );
     }
 
     public function testLessThanOneBarWillAlwaysShowOneBar()
     {
-        $result = $this->progressBar->render(5, array(
-            'yellow' => 1,
-            'blue'   => 19,
-        ));
-        $this->assert($result, equals, $this->color(1, 'yellow') . $this->color(4, 'blue'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'yellow' => 1,
+                'blue' => 19,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(1, 'yellow') . $this->color(4, 'blue')
+        );
     }
 
     public function testZeroIsAllowed()
     {
-        $result = $this->progressBar->render(5, array(
-            'yellow' => 0,
-            'blue'   => 19,
-        ));
-        $this->assert($result, equals, $this->color(0, 'yellow') . $this->color(5, 'blue'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'yellow' => 0,
+                'blue' => 19,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(0, 'yellow') . $this->color(5, 'blue')
+        );
     }
 
     public function testNegativeValuesAreAllowed()
     {
-        $result = $this->progressBar->render(5, array(
-            'yellow' => -5,
-            'blue'   => 19,
-        ));
-        $this->assert($result, equals, $this->color(0, 'yellow') . $this->color(5, 'blue'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'yellow' => -5,
+                'blue' => 19,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(0, 'yellow') . $this->color(5, 'blue')
+        );
     }
 
     public function testTotalIsZero()
     {
-        $result = $this->progressBar->render(5, array(
-            'yellow' => 1,
-            'blue'   => -1,
-        ));
-        $this->assert($result, equals, $this->color(0, 'yellow') . $this->color(0, 'blue'));
+        $result = $this->progressBar->render(
+            5,
+            array(
+                'yellow' => 1,
+                'blue' => -1,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(0, 'yellow') . $this->color(0, 'blue')
+        );
     }
 
     /**

--- a/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTestCase.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTestCase.php
@@ -2,8 +2,8 @@
 
 namespace Concise\Console\ResultPrinter\Utilities;
 
-use Concise\TestCase;
 use Colors\Color;
+use Concise\TestCase;
 
 class ProgressBarTestCase extends TestCase
 {
@@ -11,6 +11,6 @@ class ProgressBarTestCase extends TestCase
     {
         $c = new Color();
 
-        return (string) $c(str_repeat(' ', $size))->highlight($color);
+        return (string)$c(str_repeat(' ', $size))->highlight($color);
     }
 }

--- a/tests/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBarTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBarTest.php
@@ -4,8 +4,7 @@ namespace Concise\Console\ResultPrinter\Utilities;
 
 class ProportionalProgressBarTest extends ProgressBarTestCase
 {
-    public function testAProportionalProgressBarWillScaleDownAndFillToTheTotalWidth(
-    )
+    public function testAProportionalProgressBarWillScaleDownAndFillToTheTotalWidth()
     {
         $progressBar = new ProportionalProgressBar();
         $result = $progressBar->renderProportional(

--- a/tests/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBarTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/ProportionalProgressBarTest.php
@@ -4,24 +4,41 @@ namespace Concise\Console\ResultPrinter\Utilities;
 
 class ProportionalProgressBarTest extends ProgressBarTestCase
 {
-    public function testAProportionalProgressBarWillScaleDownAndFillToTheTotalWidth()
+    public function testAProportionalProgressBarWillScaleDownAndFillToTheTotalWidth(
+    )
     {
         $progressBar = new ProportionalProgressBar();
-        $result = $progressBar->renderProportional(10, 40, array(
-            'yellow' => 1,
-            'blue'   => 19,
-        ));
-        $this->assert($result, equals, $this->color(1, 'yellow') . $this->color(4, 'blue') . '_____');
+        $result = $progressBar->renderProportional(
+            10,
+            40,
+            array(
+                'yellow' => 1,
+                'blue' => 19,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(1, 'yellow') . $this->color(4, 'blue') . '_____'
+        );
     }
 
     public function testZeroTotalMeans100Percent()
     {
         $progressBar = new ProportionalProgressBar();
-        $result = $progressBar->renderProportional(10, 40, array(
-            'yellow' => 1,
-            'blue'   => 19,
-        ));
-        $this->assert($result, equals, $this->color(1, 'yellow') . $this->color(4, 'blue') . '_____');
+        $result = $progressBar->renderProportional(
+            10,
+            40,
+            array(
+                'yellow' => 1,
+                'blue' => 19,
+            )
+        );
+        $this->assert(
+            $result,
+            equals,
+            $this->color(1, 'yellow') . $this->color(4, 'blue') . '_____'
+        );
     }
 
     public function testNoPartsMeansZeroPercent()

--- a/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
@@ -2,11 +2,11 @@
 
 namespace Concise\Console\ResultPrinter\Utilities;
 
+use Colors\Color;
 use Concise\TestCase;
 use Exception;
 use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit_Runner_BaseTestRunner;
-use Colors\Color;
 
 /**
  * @group cli
@@ -23,46 +23,90 @@ class RenderIssueTest extends TestCase
     {
         parent::setUp();
         $this->issue = new RenderIssue();
-        $this->test = $this->mock('PHPUnit_Framework_TestCase')
-                           ->stub(array('getName' => 'foo'))
-                           ->get();
+        $this->test = $this->mock('PHPUnit_Framework_TestCase')->stub(
+                array('getName' => 'foo')
+            )->get();
         $this->exception = new Exception('foo bar');
     }
 
     public function testStartsWithTheIssueNumber()
     {
-        $this->assert($this->issue->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 123, $this->test, $this->exception), starts_with, '123. ');
+        $this->assert(
+            $this->issue->render(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                123,
+                $this->test,
+                $this->exception
+            ),
+            starts_with,
+            '123. '
+        );
     }
 
     public function testIncludesTestClass()
     {
         $class = get_class($this->test);
-        $this->assert($this->issue->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 123, $this->test, $this->exception), contains_string, $class);
+        $this->assert(
+            $this->issue->render(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                123,
+                $this->test,
+                $this->exception
+            ),
+            contains_string,
+            $class
+        );
     }
 
     public function testIncludesTheMethodName()
     {
-        $this->assert($this->issue->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 123, $this->test, $this->exception), contains_string, 'foo');
+        $this->assert(
+            $this->issue->render(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                123,
+                $this->test,
+                $this->exception
+            ),
+            contains_string,
+            'foo'
+        );
     }
 
     public function testIncludesExceptionMessage()
     {
-        $this->assert($this->issue->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 123, $this->test, $this->exception), contains_string, $this->exception->getMessage());
+        $this->assert(
+            $this->issue->render(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                123,
+                $this->test,
+                $this->exception
+            ),
+            contains_string,
+            $this->exception->getMessage()
+        );
     }
 
     protected function getTraceSimplifier($return)
     {
-        return $this->mock('Concise\Console\ResultPrinter\Utilities\TraceSimplifier')
-                    ->expect('render')->andReturn($return)
-                    ->get();
+        return $this->mock(
+            'Concise\Console\ResultPrinter\Utilities\TraceSimplifier'
+        )->expect('render')->andReturn($return)->get();
     }
 
-    protected function render($status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, $issueNumber = 0, $text = "foo\nbar")
-    {
+    protected function render(
+        $status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+        $issueNumber = 0,
+        $text = "foo\nbar"
+    ) {
         $simplifier = $this->getTraceSimplifier($text);
         $issue = new RenderIssue($simplifier);
 
-        return $issue->render($status, $issueNumber, $this->test, $this->exception);
+        return $issue->render(
+            $status,
+            $issueNumber,
+            $this->test,
+            $this->exception
+        );
     }
 
     public function testWillRenderSimplifiedTraceUnderneathTheTitle()
@@ -83,7 +127,8 @@ class RenderIssueTest extends TestCase
         $this->assert($result, contains_string, "\033[90mbar");
     }
 
-    public function testClearFormattingAfterStackTraceToPreventUnwantedTextFromBeingColored()
+    public function testClearFormattingAfterStackTraceToPreventUnwantedTextFromBeingColored(
+    )
     {
         $result = $this->render();
         $this->assert($result, contains_string, "bar\033[0m");
@@ -101,29 +146,38 @@ class RenderIssueTest extends TestCase
         $this->assert($result, contains_string, "\033[44m  \033[0m ");
     }
 
-    public function testWhenIssueNumberGoesAbove10ExtraPaddingWillBeProvidedToKeepItAligned()
+    public function testWhenIssueNumberGoesAbove10ExtraPaddingWillBeProvidedToKeepItAligned(
+    )
     {
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $result =
+            $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "\033[41m  \033[0m  ");
     }
 
     public function testTestTitilesAreColored()
     {
         $c = new Color();
-        $this->test = $this->mock('PHPUnit_Framework_TestCase')
-                           ->setCustomClassName('PHPUnit_Framework_TestCase_57c3cc10')
-                           ->stub(array('getName' => 'foo'))
-                           ->get();
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
-        $this->assert($result, contains_string, (string) $c("PHPUnit_Framework_TestCase_57c3cc10::foo")->red());
+        $this->test =
+            $this->mock('PHPUnit_Framework_TestCase')->setCustomClassName(
+                    'PHPUnit_Framework_TestCase_57c3cc10'
+                )->stub(array('getName' => 'foo'))->get();
+        $result =
+            $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $this->assert(
+            $result,
+            contains_string,
+            (string)$c("PHPUnit_Framework_TestCase_57c3cc10::foo")->red()
+        );
     }
 
     public function testCanAcceptATestSuite()
     {
-        $this->test = $this->mock('\PHPUnit_Framework_TestSuite')->disableConstructor()
-                           ->stub(array('getName' => 'foo'))
-                           ->get();
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $this->test = $this->mock('\PHPUnit_Framework_TestSuite')
+            ->disableConstructor()
+            ->stub(array('getName' => 'foo'))
+            ->get();
+        $result =
+            $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "foo");
     }
 
@@ -140,20 +194,25 @@ class RenderIssueTest extends TestCase
 
     public function testPHPUnitDiffsAreShown()
     {
-        $failure = $this->mock($this->getComparisonFailure(), array('foo', 'bar', 'foo', 'bar'))
-                        ->expect('getDiff')->andReturn('foobar')
-                        ->get();
-        $this->exception = new PHPUnit_Framework_ExpectationFailedException('', $failure);
+        $failure = $this->mock(
+            $this->getComparisonFailure(),
+            array('foo', 'bar', 'foo', 'bar')
+        )->expect('getDiff')->andReturn('foobar')->get();
+        $this->exception =
+            new PHPUnit_Framework_ExpectationFailedException('', $failure);
 
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $result =
+            $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "foobar");
     }
 
     public function testPHPUnitDiffsAreShownOnlyIfAvailable()
     {
-        $this->exception = new PHPUnit_Framework_ExpectationFailedException('', null);
+        $this->exception =
+            new PHPUnit_Framework_ExpectationFailedException('', null);
 
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
+        $result =
+            $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert($result, contains_string, "10.");
     }
 
@@ -163,18 +222,31 @@ class RenderIssueTest extends TestCase
      */
     public function testIssueNumberMustBeAnInteger()
     {
-        $this->issue->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 'foo', $this->test, $this->exception);
+        $this->issue->render(
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+            'foo',
+            $this->test,
+            $this->exception
+        );
     }
 
     public function testNameIsNotAppendedIfItsNotATestCase()
     {
-        $renderIssue = $this->niceMock('Concise\Console\ResultPrinter\Utilities\RenderIssue')
-            ->expose('getHeading')
-            ->get();
+        $renderIssue = $this->niceMock(
+            'Concise\Console\ResultPrinter\Utilities\RenderIssue'
+        )->expose('getHeading')->get();
 
         $test = $this->mock('PHPUnit_Framework_Test')->get();
 
-        $this->assert($renderIssue->getHeading(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 1, $test), does_not_contain_string, '::');
+        $this->assert(
+            $renderIssue->getHeading(
+                PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+                1,
+                $test
+            ),
+            does_not_contain_string,
+            '::'
+        );
     }
 
     /**
@@ -182,7 +254,11 @@ class RenderIssueTest extends TestCase
      */
     public function testWillRemoveCarriageReturns()
     {
-        $result = $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 0, "foo\n\rbar");
+        $result = $this->render(
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE,
+            0,
+            "foo\n\rbar"
+        );
         $this->assert($result, does_not_contain_string, "\r");
     }
 }

--- a/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/RenderIssueTest.php
@@ -24,8 +24,8 @@ class RenderIssueTest extends TestCase
         parent::setUp();
         $this->issue = new RenderIssue();
         $this->test = $this->mock('PHPUnit_Framework_TestCase')->stub(
-                array('getName' => 'foo')
-            )->get();
+            array('getName' => 'foo')
+        )->get();
         $this->exception = new Exception('foo bar');
     }
 
@@ -127,8 +127,7 @@ class RenderIssueTest extends TestCase
         $this->assert($result, contains_string, "\033[90mbar");
     }
 
-    public function testClearFormattingAfterStackTraceToPreventUnwantedTextFromBeingColored(
-    )
+    public function testClearFormattingAfterStackTraceToPreventUnwantedTextFromBeingColored()
     {
         $result = $this->render();
         $this->assert($result, contains_string, "bar\033[0m");
@@ -146,8 +145,7 @@ class RenderIssueTest extends TestCase
         $this->assert($result, contains_string, "\033[44m  \033[0m ");
     }
 
-    public function testWhenIssueNumberGoesAbove10ExtraPaddingWillBeProvidedToKeepItAligned(
-    )
+    public function testWhenIssueNumberGoesAbove10ExtraPaddingWillBeProvidedToKeepItAligned()
     {
         $result =
             $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
@@ -159,8 +157,8 @@ class RenderIssueTest extends TestCase
         $c = new Color();
         $this->test =
             $this->mock('PHPUnit_Framework_TestCase')->setCustomClassName(
-                    'PHPUnit_Framework_TestCase_57c3cc10'
-                )->stub(array('getName' => 'foo'))->get();
+                'PHPUnit_Framework_TestCase_57c3cc10'
+            )->stub(array('getName' => 'foo'))->get();
         $result =
             $this->render(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, 10);
         $this->assert(

--- a/tests/Concise/Console/ResultPrinter/Utilities/TraceSimplifierTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/TraceSimplifierTest.php
@@ -19,105 +19,161 @@ class TraceSimplifierTest extends TestCase
 
     public function testOneItemWillPrintSimplifiedFile()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'file' => getcwd() . '/foo.php',
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'file' => getcwd() . '/foo.php',
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), contains_string, 'foo.php');
+            contains_string,
+            'foo.php'
+        );
     }
 
     public function testWillSkipTraceLineIfItsTheConciseExecutable()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'file' => getcwd() . '/bin/concise',
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'file' => getcwd() . '/bin/concise',
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), equals, '');
+            equals,
+            ''
+        );
     }
 
     public function testWillSkipTraceLineIfThePathIsInTheVendorFolder()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'file' => getcwd() . '/vendor/a',
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'file' => getcwd() . '/vendor/a',
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), equals, '');
+            equals,
+            ''
+        );
     }
 
     public function testUsesUnknownFileIfNotSpecified()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), contains_string, '(unknown file)');
+            contains_string,
+            '(unknown file)'
+        );
     }
 
     public function testWillUseAQuestionMarkIfTheLineIsNotSpecified()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), contains_string, 'Line ?');
+            contains_string,
+            'Line ?'
+        );
     }
 
     public function testWillIncludeLineNumber()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'line' => 123,
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'line' => 123,
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), contains_string, 'Line 123');
+            contains_string,
+            'Line 123'
+        );
     }
 
     public function testWillGroupLinesUnderTheSameHeadingIfTheyAreTheSameFile()
     {
-        $result = $this->simplifier->render(array(
+        $result = $this->simplifier->render(
             array(
-                'file' => getcwd() . '/foo.php',
-                'function' => 'myFunction',
-            ),
-            array(
-                'file' => getcwd() . '/foo.php',
-                'function' => 'myFunction',
-            ),
-        ));
+                array(
+                    'file' => getcwd() . '/foo.php',
+                    'function' => 'myFunction',
+                ),
+                array(
+                    'file' => getcwd() . '/foo.php',
+                    'function' => 'myFunction',
+                ),
+            )
+        );
         $this->assert(substr_count($result, 'foo.php'), equals, 1);
     }
 
     public function testWillIncludeTheFunctionName()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'function' => 'myFunction',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'function' => 'myFunction',
+                    ),
+                )
             ),
-        )), contains_string, 'myFunction()');
+            contains_string,
+            'myFunction()'
+        );
     }
 
     public function testWillIncludeClassIfAvailable()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'function' => 'myFunction',
-                'class'    => 'MyClass',
-                'type'     => '',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'function' => 'myFunction',
+                        'class' => 'MyClass',
+                        'type' => '',
+                    ),
+                )
             ),
-        )), contains_string, 'MyClass');
+            contains_string,
+            'MyClass'
+        );
     }
 
     public function testWillIncludeTypeIfClassIsAvailable()
     {
-        $this->assert($this->simplifier->render(array(
-            array(
-                'function' => 'myFunction',
-                'class'    => 'MyClass',
-                'type'     => '::',
+        $this->assert(
+            $this->simplifier->render(
+                array(
+                    array(
+                        'function' => 'myFunction',
+                        'class' => 'MyClass',
+                        'type' => '::',
+                    ),
+                )
             ),
-        )), contains_string, 'MyClass::myFunction()');
+            contains_string,
+            'MyClass::myFunction()'
+        );
     }
 }

--- a/tests/Concise/Console/TestColorsTest.php
+++ b/tests/Concise/Console/TestColorsTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Console;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class TestColorsTest extends TestCase
 {

--- a/tests/Concise/Console/TestRunner/DefaultTestRunnerTest.php
+++ b/tests/Concise/Console/TestRunner/DefaultTestRunnerTest.php
@@ -2,12 +2,16 @@
 
 namespace Concise\Console\TestRunner;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class DefaultTestRunnerTest extends TestCase
 {
     public function testTestRunnerExtendsPHPUnit()
     {
-        $this->assert(new DefaultTestRunner(), instance_of, 'PHPUnit_TextUI_TestRunner');
+        $this->assert(
+            new DefaultTestRunner(),
+            instance_of,
+            'PHPUnit_TextUI_TestRunner'
+        );
     }
 }

--- a/tests/Concise/Console/Theme/ThemeTestCase.php
+++ b/tests/Concise/Console/Theme/ThemeTestCase.php
@@ -2,9 +2,9 @@
 
 namespace Concise\Console\Theme;
 
+use Colors\Color;
 use Concise\TestCase;
 use PHPUnit_Runner_BaseTestRunner;
-use Colors\Color;
 
 class ColorStub extends Color
 {
@@ -56,11 +56,19 @@ abstract class ThemeTestCase extends TestCase
 
     public function testMustImplementColorTheme()
     {
-        $this->assert($this->theme, instance_of, 'Concise\Console\Theme\ThemeInterface');
+        $this->assert(
+            $this->theme,
+            instance_of,
+            'Concise\Console\Theme\ThemeInterface'
+        );
     }
 
     public function testMustExtendAbstractTheme()
     {
-        $this->assert($this->theme, instance_of, 'Concise\Console\Theme\AbstractTheme');
+        $this->assert(
+            $this->theme,
+            instance_of,
+            'Concise\Console\Theme\AbstractTheme'
+        );
     }
 }

--- a/tests/Concise/Matcher/AbstractExceptionTestCase.php
+++ b/tests/Concise/Matcher/AbstractExceptionTestCase.php
@@ -15,10 +15,17 @@ abstract class AbstractExceptionTestCase extends AbstractMatcherTestCase
     protected function createExceptionTests(array $data)
     {
         $throw = array(
-            'throwNothing' => function () {},
-            'throwException' => function () { throw new \Exception(); },
-            'throwMyException' => function () { throw new \Concise\Matcher\MyException(); },
-            'throwOtherException' => function () { throw new \Concise\Matcher\OtherException(); },
+            'throwNothing' => function () {
+            },
+            'throwException' => function () {
+                throw new \Exception();
+            },
+            'throwMyException' => function () {
+                throw new \Concise\Matcher\MyException();
+            },
+            'throwOtherException' => function () {
+                throw new \Concise\Matcher\OtherException();
+            },
         );
         $expect = array(
             'expectException' => 'Exception',

--- a/tests/Concise/Matcher/AbstractMatcherTestCase.php
+++ b/tests/Concise/Matcher/AbstractMatcherTestCase.php
@@ -2,14 +2,18 @@
 
 namespace Concise\Matcher;
 
-use \Concise\TestCase;
-use \Concise\Syntax\MatcherParser;
+use Concise\Syntax\MatcherParser;
+use Concise\TestCase;
 
 abstract class AbstractMatcherTestCase extends TestCase
 {
     public function testExtendsAbstractMatcher()
     {
-        $this->assert($this->matcher, is_instance_of, '\Concise\Matcher\AbstractMatcher');
+        $this->assert(
+            $this->matcher,
+            is_instance_of,
+            '\Concise\Matcher\AbstractMatcher'
+        );
     }
 
     public function testCanRegisterMatcher()
@@ -29,10 +33,13 @@ abstract class AbstractMatcherTestCase extends TestCase
     }
 
     /**
-	 * @param string $syntax
-	 */
-    protected function assertMatcherFailureMessage($syntax, array $args, $failureMessage)
-    {
+     * @param string $syntax
+     */
+    protected function assertMatcherFailureMessage(
+        $syntax,
+        array $args,
+        $failureMessage
+    ) {
         try {
             $this->matcher->match($syntax, $args);
             $this->fail("Expected assertion to fail.");
@@ -42,8 +49,8 @@ abstract class AbstractMatcherTestCase extends TestCase
     }
 
     /**
-	 * @param string $syntax
-	 */
+     * @param string $syntax
+     */
     protected function assertMatcherFailure($syntax, array $args = array())
     {
         try {
@@ -54,8 +61,8 @@ abstract class AbstractMatcherTestCase extends TestCase
     }
 
     /**
-	 * @param string $syntax
-	 */
+     * @param string $syntax
+     */
     protected function assertMatcherSuccess($syntax, array $args = array())
     {
         $this->assert($this->matcher->match($syntax, $args));

--- a/tests/Concise/Matcher/AbstractNestedMatcherTestCase.php
+++ b/tests/Concise/Matcher/AbstractNestedMatcherTestCase.php
@@ -9,7 +9,11 @@ abstract class AbstractNestedMatcherTestCase extends AbstractMatcherTestCase
      */
     public function testThisMatcherCanBeNested()
     {
-        $this->assert($this->matcher, is_instance_of, '\Concise\Matcher\AbstractNestedMatcher');
+        $this->assert(
+            $this->matcher,
+            is_instance_of,
+            '\Concise\Matcher\AbstractNestedMatcher'
+        );
     }
 
     abstract public function testNestedAssertionSuccess();

--- a/tests/Concise/Matcher/BetweenTest.php
+++ b/tests/Concise/Matcher/BetweenTest.php
@@ -48,7 +48,11 @@ class BetweenTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert(5, between, 0, 'and', 10), exactly_equals, 5);
+        $this->assert(
+            $this->assert(5, between, 0, 'and', 10),
+            exactly_equals,
+            5
+        );
     }
 
     /**
@@ -56,6 +60,10 @@ class BetweenTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert(5, between, 0, 'and', 10), exactly_equals, 6);
+        $this->assertFailure(
+            $this->assert(5, between, 0, 'and', 10),
+            exactly_equals,
+            6
+        );
     }
 }

--- a/tests/Concise/Matcher/ContainsStringIgnoringCaseTest.php
+++ b/tests/Concise/Matcher/ContainsStringIgnoringCaseTest.php
@@ -38,7 +38,11 @@ class ContainsStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert('foobar', contains_string, 'Foo', ignoring_case), exactly_equals, 'foobar');
+        $this->assert(
+            $this->assert('foobar', contains_string, 'Foo', ignoring_case),
+            exactly_equals,
+            'foobar'
+        );
     }
 
     /**
@@ -46,6 +50,10 @@ class ContainsStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert('foobar', contains_string, 'Foo', ignoring_case), exactly_equals, 'Foo');
+        $this->assertFailure(
+            $this->assert('foobar', contains_string, 'Foo', ignoring_case),
+            exactly_equals,
+            'Foo'
+        );
     }
 }

--- a/tests/Concise/Matcher/ContainsStringTest.php
+++ b/tests/Concise/Matcher/ContainsStringTest.php
@@ -38,7 +38,11 @@ class ContainsStringTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert('foobar', contains_string, 'oob'), exactly_equals, 'foobar');
+        $this->assert(
+            $this->assert('foobar', contains_string, 'oob'),
+            exactly_equals,
+            'foobar'
+        );
     }
 
     /**
@@ -46,6 +50,10 @@ class ContainsStringTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert('foobar', contains_string, 'oob'), exactly_equals, 'Foo');
+        $this->assertFailure(
+            $this->assert('foobar', contains_string, 'oob'),
+            exactly_equals,
+            'Foo'
+        );
     }
 }

--- a/tests/Concise/Matcher/DateIsAfterTest.php
+++ b/tests/Concise/Matcher/DateIsAfterTest.php
@@ -21,16 +21,44 @@ class DateIsAfterTest extends AbstractNestedMatcherTestCase
             'before' => array('2014-01-02', '2014-02-02', false),
             'after' => array('2014-03-02', '2014-02-02', true),
             'equal' => array('2014-02-02', '2014-02-02', false),
-            'timezone before' => array('2005-08-15T15:52:01+00:00', '2005-08-15T15:52:01+10:00', true),
-            'timezone after' => array('2005-08-15T15:52:01+10:00', '2005-08-15T15:52:01+00:00', false),
-            'timezone equal' => array('2005-08-15T15:52:01+00:00', '2005-08-15T05:52:01-10:00', false),
+            'timezone before' => array(
+                '2005-08-15T15:52:01+00:00',
+                '2005-08-15T15:52:01+10:00',
+                true
+            ),
+            'timezone after' => array(
+                '2005-08-15T15:52:01+10:00',
+                '2005-08-15T15:52:01+00:00',
+                false
+            ),
+            'timezone equal' => array(
+                '2005-08-15T15:52:01+00:00',
+                '2005-08-15T05:52:01-10:00',
+                false
+            ),
             'invalid left' => array('foo', '2014-02-02', false),
             'invalid right' => array('2014-02-02', 'foo', false),
             'invalid both' => array('foo', 'bar', false),
-            'datetime left' => array(new DateTime('2014-01-02'), '2014-02-02', false),
-            'datetime right' => array('2014-01-02', new DateTime('2014-02-02'), false),
-            'datetime both' => array(new DateTime('2014-01-02'), new DateTime('2014-02-02'), false),
-            'datetime equal' => array(new DateTime('2014-01-02'), new DateTime('2014-01-02'), false),
+            'datetime left' => array(
+                new DateTime('2014-01-02'),
+                '2014-02-02',
+                false
+            ),
+            'datetime right' => array(
+                '2014-01-02',
+                new DateTime('2014-02-02'),
+                false
+            ),
+            'datetime both' => array(
+                new DateTime('2014-01-02'),
+                new DateTime('2014-02-02'),
+                false
+            ),
+            'datetime equal' => array(
+                new DateTime('2014-01-02'),
+                new DateTime('2014-01-02'),
+                false
+            ),
             'epoch left' => array(1413705413, '2014-12-19', false),
             'epoch right' => array('2014-01-02', 1413705413, false),
             'epoch both' => array(1413705403, 1413705413, false),
@@ -60,7 +88,11 @@ class DateIsAfterTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert(date, '2014-03-02', is_after, '2014-02-02'), exactly_equals, '2014-03-02');
+        $this->assert(
+            $this->assert(date, '2014-03-02', is_after, '2014-02-02'),
+            exactly_equals,
+            '2014-03-02'
+        );
     }
 
     /**
@@ -68,6 +100,10 @@ class DateIsAfterTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert(date, '2014-03-02', is_after, '2014-02-02'), exactly_equals, '2014-03-01');
+        $this->assertFailure(
+            $this->assert(date, '2014-03-02', is_after, '2014-02-02'),
+            exactly_equals,
+            '2014-03-01'
+        );
     }
 }

--- a/tests/Concise/Matcher/DateIsBeforeTest.php
+++ b/tests/Concise/Matcher/DateIsBeforeTest.php
@@ -21,16 +21,44 @@ class DateIsBeforeTest extends AbstractNestedMatcherTestCase
             'before' => array('2014-01-02', '2014-02-02', true),
             'after' => array('2014-03-02', '2014-02-02', false),
             'equal' => array('2014-02-02', '2014-02-02', false),
-            'timezone before' => array('2005-08-15T15:52:01+00:00', '2005-08-15T15:52:01+10:00', false),
-            'timezone after' => array('2005-08-15T15:52:01+10:00', '2005-08-15T15:52:01+00:00', true),
-            'timezone equal' => array('2005-08-15T15:52:01+00:00', '2005-08-15T05:52:01-10:00', false),
+            'timezone before' => array(
+                '2005-08-15T15:52:01+00:00',
+                '2005-08-15T15:52:01+10:00',
+                false
+            ),
+            'timezone after' => array(
+                '2005-08-15T15:52:01+10:00',
+                '2005-08-15T15:52:01+00:00',
+                true
+            ),
+            'timezone equal' => array(
+                '2005-08-15T15:52:01+00:00',
+                '2005-08-15T05:52:01-10:00',
+                false
+            ),
             'invalid left' => array('foo', '2014-02-02', false),
             'invalid right' => array('2014-02-02', 'foo', false),
             'invalid both' => array('foo', 'bar', false),
-            'datetime left' => array(new DateTime('2014-01-02'), '2014-02-02', true),
-            'datetime right' => array('2014-01-02', new DateTime('2014-02-02'), true),
-            'datetime both' => array(new DateTime('2014-01-02'), new DateTime('2014-02-02'), true),
-            'datetime equal' => array(new DateTime('2014-01-02'), new DateTime('2014-01-02'), false),
+            'datetime left' => array(
+                new DateTime('2014-01-02'),
+                '2014-02-02',
+                true
+            ),
+            'datetime right' => array(
+                '2014-01-02',
+                new DateTime('2014-02-02'),
+                true
+            ),
+            'datetime both' => array(
+                new DateTime('2014-01-02'),
+                new DateTime('2014-02-02'),
+                true
+            ),
+            'datetime equal' => array(
+                new DateTime('2014-01-02'),
+                new DateTime('2014-01-02'),
+                false
+            ),
             'epoch left' => array(1413705413, '2014-12-19', true),
             'epoch right' => array('2014-01-02', 1413705413, true),
             'epoch both' => array(1413705403, 1413705413, true),
@@ -60,7 +88,11 @@ class DateIsBeforeTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert(date, '2014-01-02', is_before, '2014-02-02'), exactly_equals, '2014-01-02');
+        $this->assert(
+            $this->assert(date, '2014-01-02', is_before, '2014-02-02'),
+            exactly_equals,
+            '2014-01-02'
+        );
     }
 
     /**
@@ -68,6 +100,10 @@ class DateIsBeforeTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert(date, '2014-01-02', is_before, '2014-02-02'), exactly_equals, '2014-01-01');
+        $this->assertFailure(
+            $this->assert(date, '2014-01-02', is_before, '2014-02-02'),
+            exactly_equals,
+            '2014-01-01'
+        );
     }
 }

--- a/tests/Concise/Matcher/DidNotMatchExceptionTest.php
+++ b/tests/Concise/Matcher/DidNotMatchExceptionTest.php
@@ -8,6 +8,10 @@ class DidNotMatchExceptionTest extends TestCase
 {
     public function testIsATypeOfException()
     {
-        $this->assert(new DidNotMatchException(), is_an_instance_of, '\Exception');
+        $this->assert(
+            new DidNotMatchException(),
+            is_an_instance_of,
+            '\Exception'
+        );
     }
 }

--- a/tests/Concise/Matcher/DoesNotContainStringIgnoringCaseTest.php
+++ b/tests/Concise/Matcher/DoesNotContainStringIgnoringCaseTest.php
@@ -15,7 +15,12 @@ class DoesNotContainStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
 
     public function testSuccessIfStringContainsASubstring()
     {
-        $this->assertFailure('foobar', does_not_contain_string, 'oob', ignoring_case);
+        $this->assertFailure(
+            'foobar',
+            does_not_contain_string,
+            'oob',
+            ignoring_case
+        );
     }
 
     public function testFailsIfSubstringDoesNotExistInString()
@@ -25,7 +30,12 @@ class DoesNotContainStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
 
     public function testIsNotSensitiveToCase()
     {
-        $this->assertFailure('foobar', does_not_contain_string, 'Foo', ignoring_case);
+        $this->assertFailure(
+            'foobar',
+            does_not_contain_string,
+            'Foo',
+            ignoring_case
+        );
     }
 
     public function tags()
@@ -38,7 +48,16 @@ class DoesNotContainStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert('foobar', does_not_contain_string, 'baz', ignoring_case), exactly_equals, 'foobar');
+        $this->assert(
+            $this->assert(
+                'foobar',
+                does_not_contain_string,
+                'baz',
+                ignoring_case
+            ),
+            exactly_equals,
+            'foobar'
+        );
     }
 
     /**
@@ -46,6 +65,15 @@ class DoesNotContainStringIgnoringCaseTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert('foobar', does_not_contain_string, 'baz', ignoring_case), exactly_equals, 'Foo');
+        $this->assertFailure(
+            $this->assert(
+                'foobar',
+                does_not_contain_string,
+                'baz',
+                ignoring_case
+            ),
+            exactly_equals,
+            'Foo'
+        );
     }
 }

--- a/tests/Concise/Matcher/DoesNotContainStringTest.php
+++ b/tests/Concise/Matcher/DoesNotContainStringTest.php
@@ -38,7 +38,11 @@ class DoesNotContainStringTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert('foobar', does_not_contain_string, 'baz'), exactly_equals, 'foobar');
+        $this->assert(
+            $this->assert('foobar', does_not_contain_string, 'baz'),
+            exactly_equals,
+            'foobar'
+        );
     }
 
     /**
@@ -46,6 +50,10 @@ class DoesNotContainStringTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert('foobar', does_not_contain_string, 'baz'), exactly_equals, 'Foo');
+        $this->assertFailure(
+            $this->assert('foobar', does_not_contain_string, 'baz'),
+            exactly_equals,
+            'Foo'
+        );
     }
 }

--- a/tests/Concise/Matcher/DoesNotHaveItemTest.php
+++ b/tests/Concise/Matcher/DoesNotHaveItemTest.php
@@ -15,22 +15,42 @@ class DoesNotHaveItemTest extends AbstractMatcherTestCase
 
     public function testKeyValuePairExists()
     {
-        $this->assertFailure(array("foo" => 123), does_not_have_key, "foo", with_value, 123);
+        $this->assertFailure(
+            array("foo" => 123),
+            does_not_have_key,
+            "foo",
+            with_value,
+            123
+        );
     }
 
     public function testAlternativeSyntaxForItemExists()
     {
-        $this->assertFailure(array("foo" => 123), does_not_have_item, array("foo" => 123));
+        $this->assertFailure(
+            array("foo" => 123),
+            does_not_have_item,
+            array("foo" => 123)
+        );
     }
 
     public function testItemDoesNotExist()
     {
-        $this->assert(array("foo" => 123), does_not_have_item, array("foo" => 124));
+        $this->assert(
+            array("foo" => 123),
+            does_not_have_item,
+            array("foo" => 124)
+        );
     }
 
     public function testItemExistsInMultipleItems()
     {
-        $this->assertFailure(array("foo" => 123, "bar" => "baz"), does_not_have_key, "foo", with_value, 123);
+        $this->assertFailure(
+            array("foo" => 123, "bar" => "baz"),
+            does_not_have_key,
+            "foo",
+            with_value,
+            123
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/DoesNotHaveKeysTest.php
+++ b/tests/Concise/Matcher/DoesNotHaveKeysTest.php
@@ -25,12 +25,20 @@ class DoesNotHaveKeysTest extends AbstractMatcherTestCase
 
     public function testArrayKeysCanBeInAnyOrder()
     {
-        $this->assertFailure(array("a" => 123, "b" => 456), does_not_have_keys, array("b", "a"));
+        $this->assertFailure(
+            array("a" => 123, "b" => 456),
+            does_not_have_keys,
+            array("b", "a")
+        );
     }
 
     public function testArrayKeysCanBeASubset()
     {
-        $this->assertFailure(array("a" => 123, "b" => 456), does_not_have_keys, array("b"));
+        $this->assertFailure(
+            array("a" => 123, "b" => 456),
+            does_not_have_keys,
+            array("b")
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/DoesNotThrowExceptionTest.php
+++ b/tests/Concise/Matcher/DoesNotThrowExceptionTest.php
@@ -15,23 +15,29 @@ class DoesNotThrowExceptionTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        $throwNothing = function () {};
-        $throwException = function () { throw new \Exception(); };
+        $throwNothing = function () {
+        };
+        $throwException = function () {
+            throw new \Exception();
+        };
 
         return array(
-            array($throwNothing,   false),
+            array($throwNothing, false),
             array($throwException, true),
         );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
+     * @dataProvider exceptionTests
+     */
     public function testDoesNotThrow(\Closure $method, $expectSuccess)
     {
         $success = false;
         try {
-            $success = $this->matcher->match('? does not throw exception', array($method));
+            $success = $this->matcher->match(
+                '? does not throw exception',
+                array($method)
+            );
         } catch (DidNotMatchException $e) {
             $success = false;
         }
@@ -41,10 +47,21 @@ class DoesNotThrowExceptionTest extends AbstractExceptionTestCase
     public function testDoesNotThrowMessage()
     {
         try {
-            $this->matcher->match('? does not throw exception', array(function () { throw new \Exception(); }));
+            $this->matcher->match(
+                '? does not throw exception',
+                array(
+                    function () {
+                        throw new \Exception();
+                    }
+                )
+            );
             $this->fail("Exception was not thrown.");
         } catch (DidNotMatchException $e) {
-            $this->assert("Expected exception not to be thrown.", equals, $e->getMessage());
+            $this->assert(
+                "Expected exception not to be thrown.",
+                equals,
+                $e->getMessage()
+            );
         }
     }
 

--- a/tests/Concise/Matcher/DoesNotThrowTest.php
+++ b/tests/Concise/Matcher/DoesNotThrowTest.php
@@ -15,49 +15,89 @@ class DoesNotThrowTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      'FAIL'),
-            array('throwNothing',        'expectMyException',    'FAIL'),
-            array('throwException',      'expectException',      'PASS'),
-            array('throwException',      'expectMyException',    'FAIL'),
-            array('throwMyException',    'expectException',      'PASS'),
-            array('throwMyException',    'expectMyException',    'PASS'),
-            array('throwMyException',    'expectOtherException', 'FAIL'),
-            array('throwOtherException', 'expectException',      'PASS'),
-            array('throwOtherException', 'expectMyException',    'FAIL'),
-            array('throwOtherException', 'expectOtherException', 'PASS'),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array('throwNothing', 'expectException', 'FAIL'),
+                array('throwNothing', 'expectMyException', 'FAIL'),
+                array('throwException', 'expectException', 'PASS'),
+                array('throwException', 'expectMyException', 'FAIL'),
+                array('throwMyException', 'expectException', 'PASS'),
+                array('throwMyException', 'expectMyException', 'PASS'),
+                array('throwMyException', 'expectOtherException', 'FAIL'),
+                array('throwOtherException', 'expectException', 'PASS'),
+                array('throwOtherException', 'expectMyException', 'FAIL'),
+                array('throwOtherException', 'expectOtherException', 'PASS'),
+            )
+        );
     }
 
     public function exceptionDoesNotThrowTestMessages()
     {
-        return $this->createExceptionTests(array(
-            array('throwException',      'expectException',      "Expected Exception not to be thrown, but Exception was thrown."),
-            array('throwMyException',    'expectException',      "Expected Exception not to be thrown, but Concise\Matcher\MyException was thrown."),
-            array('throwMyException',    'expectMyException',    "Expected Concise\Matcher\MyException not to be thrown, but Concise\Matcher\MyException was thrown."),
-            array('throwOtherException', 'expectException',      "Expected Exception not to be thrown, but Concise\Matcher\OtherException was thrown."),
-            array('throwOtherException', 'expectOtherException', "Expected Concise\Matcher\OtherException not to be thrown, but Concise\Matcher\OtherException was thrown."),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array(
+                    'throwException',
+                    'expectException',
+                    "Expected Exception not to be thrown, but Exception was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectException',
+                    "Expected Exception not to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectMyException',
+                    "Expected Concise\Matcher\MyException not to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+                array(
+                    'throwOtherException',
+                    'expectException',
+                    "Expected Exception not to be thrown, but Concise\Matcher\OtherException was thrown."
+                ),
+                array(
+                    'throwOtherException',
+                    'expectOtherException',
+                    "Expected Concise\Matcher\OtherException not to be thrown, but Concise\Matcher\OtherException was thrown."
+                ),
+            )
+        );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
-    public function testDoesNotThrow(\Closure $method, $expectedException, $expectToThrow)
-    {
+     * @dataProvider exceptionTests
+     */
+    public function testDoesNotThrow(
+        \Closure $method,
+        $expectedException,
+        $expectToThrow
+    ) {
         if ($expectToThrow) {
-            $this->assertMatcherSuccess('? does not throw ?', array($method, $expectedException));
+            $this->assertMatcherSuccess(
+                '? does not throw ?',
+                array($method, $expectedException)
+            );
         } else {
-            $this->assertMatcherFailure('? does not throw ?', array($method, $expectedException));
+            $this->assertMatcherFailure(
+                '? does not throw ?',
+                array($method, $expectedException)
+            );
         }
     }
 
     /**
-	 * @dataProvider exceptionDoesNotThrowTestMessages
-	 */
-    public function testDoesNotThrowMessages(\Closure $method, $expectedException, $failureMessage)
-    {
-        $this->assertMatcherFailureMessage('? does not throw ?', array($method, $expectedException), $failureMessage);
+     * @dataProvider exceptionDoesNotThrowTestMessages
+     */
+    public function testDoesNotThrowMessages(
+        \Closure $method,
+        $expectedException,
+        $failureMessage
+    ) {
+        $this->assertMatcherFailureMessage(
+            '? does not throw ?',
+            array($method, $expectedException),
+            $failureMessage
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/EqualsTest.php
+++ b/tests/Concise/Matcher/EqualsTest.php
@@ -23,8 +23,8 @@ class EqualsTest extends AbstractMatcherTestCase
     }
 
     /**
-	 * @dataProvider comparisons
-	 */
+     * @dataProvider comparisons
+     */
     public function testEquals($assertion)
     {
         $this->assert($assertion);

--- a/tests/Concise/Matcher/HasItemTest.php
+++ b/tests/Concise/Matcher/HasItemTest.php
@@ -25,12 +25,22 @@ class HasItemTest extends AbstractMatcherTestCase
 
     public function testItemDoesNotExist()
     {
-        $this->assertFailure(array("foo" => 123), has_item, array("foo" => 124));
+        $this->assertFailure(
+            array("foo" => 123),
+            has_item,
+            array("foo" => 124)
+        );
     }
 
     public function testItemExistsInMultipleItems()
     {
-        $this->assert(array("foo" => 123, "bar" => "baz"), has_key, "foo", with_value, 123);
+        $this->assert(
+            array("foo" => 123, "bar" => "baz"),
+            has_key,
+            "foo",
+            with_value,
+            123
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/HasItemsTest.php
+++ b/tests/Concise/Matcher/HasItemsTest.php
@@ -25,22 +25,38 @@ class HasItemsTest extends AbstractMatcherTestCase
 
     public function testSingleItemIsNotInSet()
     {
-        $this->assertFailure(array("foo" => 123), has_items, array("foo" => 124));
+        $this->assertFailure(
+            array("foo" => 123),
+            has_items,
+            array("foo" => 124)
+        );
     }
 
     public function testAllItemsAreInSet()
     {
-        $this->assert(array("foo" => 123, "bar" => "baz"), has_items, array("foo" => 123, "bar" => "baz"));
+        $this->assert(
+            array("foo" => 123, "bar" => "baz"),
+            has_items,
+            array("foo" => 123, "bar" => "baz")
+        );
     }
 
     public function testAllItemsAreInSubset()
     {
-        $this->assert(array("foo" => 123, "a" => "b", "bar" => "baz"), has_items, array("foo" => 123, "bar" => "baz"));
+        $this->assert(
+            array("foo" => 123, "a" => "b", "bar" => "baz"),
+            has_items,
+            array("foo" => 123, "bar" => "baz")
+        );
     }
 
     public function testSomeItemsAreInSubset()
     {
-        $this->assertFailure(array("foo" => 123, "a" => "b", "bar" => "baz"), has_items, array("foo" => 123, "bart" => 123));
+        $this->assertFailure(
+            array("foo" => 123, "a" => "b", "bar" => "baz"),
+            has_items,
+            array("foo" => 123, "bart" => 123)
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/HasKeyTest.php
+++ b/tests/Concise/Matcher/HasKeyTest.php
@@ -46,7 +46,11 @@ class HasKeyTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionSuccess()
     {
-        $this->assert($this->assert(array("abc" => 123), has_key, "abc"), exactly_equals, 123);
+        $this->assert(
+            $this->assert(array("abc" => 123), has_key, "abc"),
+            exactly_equals,
+            123
+        );
     }
 
     /**
@@ -54,6 +58,10 @@ class HasKeyTest extends AbstractNestedMatcherTestCase
      */
     public function testNestedAssertionFailure()
     {
-        $this->assertFailure($this->assert(array("abc" => 123), has_key, "abc"), exactly_equals, 124);
+        $this->assertFailure(
+            $this->assert(array("abc" => 123), has_key, "abc"),
+            exactly_equals,
+            124
+        );
     }
 }

--- a/tests/Concise/Matcher/HasPropertyTest.php
+++ b/tests/Concise/Matcher/HasPropertyTest.php
@@ -44,7 +44,11 @@ class HasPropertyTest extends AbstractNestedMatcherTestCase
     public function testNestedAssertionSuccess()
     {
         $this->obj->foo = 'bar';
-        $this->assert($this->assert($this->obj, has_property, 'foo'), exactly_equals, 'bar');
+        $this->assert(
+            $this->assert($this->obj, has_property, 'foo'),
+            exactly_equals,
+            'bar'
+        );
     }
 
     /**
@@ -53,6 +57,10 @@ class HasPropertyTest extends AbstractNestedMatcherTestCase
     public function testNestedAssertionFailure()
     {
         $this->obj->foo = 'bar';
-        $this->assertFailure($this->assert($this->obj, has_property, 'foo'), exactly_equals, 'baz');
+        $this->assertFailure(
+            $this->assert($this->obj, has_property, 'foo'),
+            exactly_equals,
+            'baz'
+        );
     }
 }

--- a/tests/Concise/Matcher/HasPropertyWithExactValueTest.php
+++ b/tests/Concise/Matcher/HasPropertyWithExactValueTest.php
@@ -16,7 +16,13 @@ class HasPropertyWithExactValueTest extends AbstractMatcherTestCase
     public function testObjectDoesNotHaveAProperty()
     {
         $obj = new \stdClass();
-        $this->assertFailure($obj, has_property, 'foo', with_exact_value, 'bar');
+        $this->assertFailure(
+            $obj,
+            has_property,
+            'foo',
+            with_exact_value,
+            'bar'
+        );
     }
 
     public function testObjectHasPropertyWithCorrectValue()
@@ -30,18 +36,42 @@ class HasPropertyWithExactValueTest extends AbstractMatcherTestCase
     {
         $obj = new \stdClass();
         $obj->foo = 'baz';
-        $this->assertFailure($obj, has_property, 'foo', with_exact_value, 'bar');
+        $this->assertFailure(
+            $obj,
+            has_property,
+            'foo',
+            with_exact_value,
+            'bar'
+        );
     }
 
     public function testObjectHasPropertyWithCorrectNonExactValue()
     {
         $obj = new \stdClass();
         $obj->foo = 123;
-        $this->assertFailure($obj, has_property, 'foo', with_exact_value, '123');
+        $this->assertFailure(
+            $obj,
+            has_property,
+            'foo',
+            with_exact_value,
+            '123'
+        );
     }
 
     public function tags()
     {
         return array(Tag::OBJECTS);
+    }
+
+    public function testObjectHasSecretPropertyWithCorrectValue()
+    {
+        $obj = new SecretProperties();
+        $this->assert($obj, has_property, 'a', with_exact_value, 'foo');
+    }
+
+    public function testObjectHasSecretPropertyWithIncorrectValue()
+    {
+        $obj = new SecretProperties();
+        $this->assertFailure($obj, has_property, 'a', with_exact_value, 'bar');
     }
 }

--- a/tests/Concise/Matcher/HasPropertyWithValueTest.php
+++ b/tests/Concise/Matcher/HasPropertyWithValueTest.php
@@ -2,6 +2,14 @@
 
 namespace Concise\Matcher;
 
+class SecretProperties
+{
+    public function __get($name)
+    {
+        return "foo";
+    }
+}
+
 /**
  * @group matcher
  */
@@ -43,5 +51,11 @@ class HasPropertyWithValueTest extends AbstractMatcherTestCase
     public function tags()
     {
         return array(Tag::OBJECTS);
+    }
+
+    public function testObjectHasSecretPropertyWithCorrectValue()
+    {
+        $obj = new SecretProperties();
+        $this->assert($obj, has_property, 'a', with_value, 'foo');
     }
 }

--- a/tests/Concise/Matcher/HasPropertyWithValueTest.php
+++ b/tests/Concise/Matcher/HasPropertyWithValueTest.php
@@ -58,4 +58,10 @@ class HasPropertyWithValueTest extends AbstractMatcherTestCase
         $obj = new SecretProperties();
         $this->assert($obj, has_property, 'a', with_value, 'foo');
     }
+
+    public function testObjectHasSecretPropertyWithIncorrectValue()
+    {
+        $obj = new SecretProperties();
+        $this->assertFailure($obj, has_property, 'a', with_value, 'bar');
+    }
 }

--- a/tests/Concise/Matcher/HasValuesTest.php
+++ b/tests/Concise/Matcher/HasValuesTest.php
@@ -25,7 +25,11 @@ class HasValuesTest extends AbstractMatcherTestCase
 
     public function testArrayValuesCanBeInAnyOrder()
     {
-        $this->assert(array("a" => 123, "b" => 456), has_values, array(123, 456));
+        $this->assert(
+            array("a" => 123, "b" => 456),
+            has_values,
+            array(123, 456)
+        );
     }
 
     public function testArrayValuesCanBeASubset()

--- a/tests/Concise/Matcher/IsAnAssociativeArrayTest.php
+++ b/tests/Concise/Matcher/IsAnAssociativeArrayTest.php
@@ -22,7 +22,8 @@ class IsAnAssociativeArrayTest extends AbstractMatcherTestCase
         $this->assert($x, is_an_associative_array);
     }
 
-    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed()
+    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed(
+    )
     {
         $x = array(
             5 => 123,

--- a/tests/Concise/Matcher/IsAnAssociativeArrayTest.php
+++ b/tests/Concise/Matcher/IsAnAssociativeArrayTest.php
@@ -22,8 +22,7 @@ class IsAnAssociativeArrayTest extends AbstractMatcherTestCase
         $this->assert($x, is_an_associative_array);
     }
 
-    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed(
-    )
+    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed()
     {
         $x = array(
             5 => 123,

--- a/tests/Concise/Matcher/IsInstanceOfTest.php
+++ b/tests/Concise/Matcher/IsInstanceOfTest.php
@@ -15,17 +15,29 @@ class IsInstanceOfTest extends AbstractMatcherTestCase
 
     public function testIsInstanceOfWithSameClass()
     {
-        $this->assert(new self(), is_an_instance_of, '\Concise\Matcher\IsInstanceOfTest');
+        $this->assert(
+            new self(),
+            is_an_instance_of,
+            '\Concise\Matcher\IsInstanceOfTest'
+        );
     }
 
     public function testIsInstanceOfWithSuperClass()
     {
-        $this->assert(new self(), instance_of, '\Concise\Matcher\AbstractMatcherTestCase');
+        $this->assert(
+            new self(),
+            instance_of,
+            '\Concise\Matcher\AbstractMatcherTestCase'
+        );
     }
 
     public function testIsInstanceOfFailure()
     {
-        $this->assertFailure(new \stdClass(), is_instance_of, '\Concise\Matcher\IsInstanceOfTest');
+        $this->assertFailure(
+            new \stdClass(),
+            is_instance_of,
+            '\Concise\Matcher\IsInstanceOfTest'
+        );
     }
 
     public function tags()
@@ -35,6 +47,10 @@ class IsInstanceOfTest extends AbstractMatcherTestCase
 
     public function testStringsRepresentingClassNamesCanBeUsed()
     {
-        $this->assert('\Concise\Matcher\IsInstanceOfTest', instance_of, '\Concise\TestCase');
+        $this->assert(
+            '\Concise\Matcher\IsInstanceOfTest',
+            instance_of,
+            '\Concise\TestCase'
+        );
     }
 }

--- a/tests/Concise/Matcher/IsNotAnAssociativeArrayTest.php
+++ b/tests/Concise/Matcher/IsNotAnAssociativeArrayTest.php
@@ -22,8 +22,7 @@ class IsNotAnAssociativeArrayTest extends AbstractMatcherTestCase
         $this->assertFailure($x, is_not_an_associative_array);
     }
 
-    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed(
-    )
+    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed()
     {
         $x = array(
             5 => 123,

--- a/tests/Concise/Matcher/IsNotAnAssociativeArrayTest.php
+++ b/tests/Concise/Matcher/IsNotAnAssociativeArrayTest.php
@@ -22,7 +22,8 @@ class IsNotAnAssociativeArrayTest extends AbstractMatcherTestCase
         $this->assertFailure($x, is_not_an_associative_array);
     }
 
-    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed()
+    public function testAnArrayIsAssociativeIfAllIndexesAreIntegersButNotZeroIndexed(
+    )
     {
         $x = array(
             5 => 123,

--- a/tests/Concise/Matcher/IsNotInstanceOfTest.php
+++ b/tests/Concise/Matcher/IsNotInstanceOfTest.php
@@ -15,22 +15,38 @@ class IsNotInstanceOfTest extends AbstractMatcherTestCase
 
     public function testIsInstanceOfWithSameClass()
     {
-        $this->assertFailure(new self(), is_not_an_instance_of, '\Concise\Matcher\IsNotInstanceOfTest');
+        $this->assertFailure(
+            new self(),
+            is_not_an_instance_of,
+            '\Concise\Matcher\IsNotInstanceOfTest'
+        );
     }
 
     public function testIsInstanceOfWithSuperClass()
     {
-        $this->assertFailure(new self(), not_instance_of, '\Concise\Matcher\AbstractMatcherTestCase');
+        $this->assertFailure(
+            new self(),
+            not_instance_of,
+            '\Concise\Matcher\AbstractMatcherTestCase'
+        );
     }
 
     public function testIsInstanceOfFailure()
     {
-        $this->assert(new \stdClass(), is_not_instance_of, '\Concise\Matcher\IsNotInstanceOfTest');
+        $this->assert(
+            new \stdClass(),
+            is_not_instance_of,
+            '\Concise\Matcher\IsNotInstanceOfTest'
+        );
     }
 
     public function testStringsRepresentingClassNamesCanBeUsed()
     {
-        $this->assertFailure('\Concise\Matcher\IsInstanceOfTest', is_not_instance_of, '\Concise\TestCase');
+        $this->assertFailure(
+            '\Concise\Matcher\IsInstanceOfTest',
+            is_not_instance_of,
+            '\Concise\TestCase'
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/NotExactlyEqualsTest.php
+++ b/tests/Concise/Matcher/NotExactlyEqualsTest.php
@@ -18,7 +18,8 @@ class NotExactlyEqualsTest extends AbstractMatcherTestCase
         $this->assert('123 is not exactly equal to 123.0');
     }
 
-    public function testIntegerAndStringRepresentationOfTheSameValueAreNotExactlyEqual()
+    public function testIntegerAndStringRepresentationOfTheSameValueAreNotExactlyEqual(
+    )
     {
         $this->assert('123 is not exactly equal to "123"');
     }

--- a/tests/Concise/Matcher/NotExactlyEqualsTest.php
+++ b/tests/Concise/Matcher/NotExactlyEqualsTest.php
@@ -18,8 +18,7 @@ class NotExactlyEqualsTest extends AbstractMatcherTestCase
         $this->assert('123 is not exactly equal to 123.0');
     }
 
-    public function testIntegerAndStringRepresentationOfTheSameValueAreNotExactlyEqual(
-    )
+    public function testIntegerAndStringRepresentationOfTheSameValueAreNotExactlyEqual()
     {
         $this->assert('123 is not exactly equal to "123"');
     }

--- a/tests/Concise/Matcher/StringDoesNotEqualFileTest.php
+++ b/tests/Concise/Matcher/StringDoesNotEqualFileTest.php
@@ -29,7 +29,11 @@ class StringDoesNotEqualFileTest extends AbstractFileTestCase
 
     public function testWillSucceedIfStringDoesMatchFile()
     {
-        $this->assertFailure('baz', does_not_equal_file, $this->createTempFile());
+        $this->assertFailure(
+            'baz',
+            does_not_equal_file,
+            $this->createTempFile()
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/ThrowsAnythingExceptTest.php
+++ b/tests/Concise/Matcher/ThrowsAnythingExceptTest.php
@@ -15,34 +15,52 @@ class ThrowsAnythingExceptTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      'FAIL'),
-            array('throwNothing',        'expectMyException',    'FAIL'),
-            array('throwException',      'expectException',      'PASS'),
-            array('throwException',      'expectMyException',    'FAIL'),
-            array('throwMyException',    'expectException',      'FAIL'),
-            array('throwMyException',    'expectMyException',    'PASS'),
-            array('throwMyException',    'expectOtherException', 'FAIL'),
-            array('throwOtherException', 'expectException',      'FAIL'),
-            array('throwOtherException', 'expectMyException',    'FAIL'),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array('throwNothing', 'expectException', 'FAIL'),
+                array('throwNothing', 'expectMyException', 'FAIL'),
+                array('throwException', 'expectException', 'PASS'),
+                array('throwException', 'expectMyException', 'FAIL'),
+                array('throwMyException', 'expectException', 'FAIL'),
+                array('throwMyException', 'expectMyException', 'PASS'),
+                array('throwMyException', 'expectOtherException', 'FAIL'),
+                array('throwOtherException', 'expectException', 'FAIL'),
+                array('throwOtherException', 'expectMyException', 'FAIL'),
+            )
+        );
     }
 
     public function exceptionThrowsAnythingExceptTestMessages()
     {
-        return $this->createExceptionTests(array(
-            array('throwException',   'expectException',   "Expected any exception except Exception to be thrown, but Exception was thrown."),
-            array('throwMyException', 'expectMyException', "Expected any exception except Concise\Matcher\MyException to be thrown, but Concise\Matcher\MyException was thrown."),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array(
+                    'throwException',
+                    'expectException',
+                    "Expected any exception except Exception to be thrown, but Exception was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectMyException',
+                    "Expected any exception except Concise\Matcher\MyException to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+            )
+        );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
-    public function testThrowsAnythingExcept(\Closure $method, $expectedException, $expectToThrow)
-    {
+     * @dataProvider exceptionTests
+     */
+    public function testThrowsAnythingExcept(
+        \Closure $method,
+        $expectedException,
+        $expectToThrow
+    ) {
         try {
-            $this->matcher->match('? throws anything except ?', array($method, $expectedException));
+            $this->matcher->match(
+                '? throws anything except ?',
+                array($method, $expectedException)
+            );
             $didThrow = false;
         } catch (DidNotMatchException $e) {
             $didThrow = true;
@@ -51,11 +69,18 @@ class ThrowsAnythingExceptTest extends AbstractExceptionTestCase
     }
 
     /**
-	 * @dataProvider exceptionThrowsAnythingExceptTestMessages
-	 */
-    public function testThrowsAnythingExceptMessages(\Closure $method, $expectedException, $failureMessage)
-    {
-        $this->assertMatcherFailureMessage('? throws anything except ?', array($method, $expectedException), $failureMessage);
+     * @dataProvider exceptionThrowsAnythingExceptTestMessages
+     */
+    public function testThrowsAnythingExceptMessages(
+        \Closure $method,
+        $expectedException,
+        $failureMessage
+    ) {
+        $this->assertMatcherFailureMessage(
+            '? throws anything except ?',
+            array($method, $expectedException),
+            $failureMessage
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/ThrowsExactlyTest.php
+++ b/tests/Concise/Matcher/ThrowsExactlyTest.php
@@ -15,50 +15,98 @@ class ThrowsExactlyTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      'FAIL'),
-            array('throwNothing',        'expectMyException',    'FAIL'),
-            array('throwException',      'expectException',      'PASS'),
-            array('throwException',      'expectMyException',    'FAIL'),
-            array('throwMyException',    'expectException',      'FAIL'),
-            array('throwMyException',    'expectMyException',    'PASS'),
-            array('throwMyException',    'expectOtherException', 'FAIL'),
-            array('throwOtherException', 'expectException',      'FAIL'),
-            array('throwOtherException', 'expectMyException',    'FAIL'),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array('throwNothing', 'expectException', 'FAIL'),
+                array('throwNothing', 'expectMyException', 'FAIL'),
+                array('throwException', 'expectException', 'PASS'),
+                array('throwException', 'expectMyException', 'FAIL'),
+                array('throwMyException', 'expectException', 'FAIL'),
+                array('throwMyException', 'expectMyException', 'PASS'),
+                array('throwMyException', 'expectOtherException', 'FAIL'),
+                array('throwOtherException', 'expectException', 'FAIL'),
+                array('throwOtherException', 'expectMyException', 'FAIL'),
+            )
+        );
     }
 
     public function exceptionThrowsExactlyTestMessages()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      "Expected exactly Exception to be thrown, but nothing was thrown."),
-            array('throwNothing',        'expectMyException',    "Expected exactly Concise\Matcher\MyException to be thrown, but nothing was thrown."),
-            array('throwException',      'expectMyException',    "Expected exactly Concise\Matcher\MyException to be thrown, but Exception was thrown."),
-            array('throwMyException',    'expectException',      "Expected exactly Exception to be thrown, but Concise\Matcher\MyException was thrown."),
-            array('throwMyException',    'expectOtherException', "Expected exactly Concise\Matcher\OtherException to be thrown, but Concise\Matcher\MyException was thrown."),
-            array('throwOtherException', 'expectException',      "Expected exactly Exception to be thrown, but Concise\Matcher\OtherException was thrown."),
-            array('throwOtherException', 'expectMyException',    "Expected exactly Concise\Matcher\MyException to be thrown, but Concise\Matcher\OtherException was thrown."),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array(
+                    'throwNothing',
+                    'expectException',
+                    "Expected exactly Exception to be thrown, but nothing was thrown."
+                ),
+                array(
+                    'throwNothing',
+                    'expectMyException',
+                    "Expected exactly Concise\Matcher\MyException to be thrown, but nothing was thrown."
+                ),
+                array(
+                    'throwException',
+                    'expectMyException',
+                    "Expected exactly Concise\Matcher\MyException to be thrown, but Exception was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectException',
+                    "Expected exactly Exception to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectOtherException',
+                    "Expected exactly Concise\Matcher\OtherException to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+                array(
+                    'throwOtherException',
+                    'expectException',
+                    "Expected exactly Exception to be thrown, but Concise\Matcher\OtherException was thrown."
+                ),
+                array(
+                    'throwOtherException',
+                    'expectMyException',
+                    "Expected exactly Concise\Matcher\MyException to be thrown, but Concise\Matcher\OtherException was thrown."
+                ),
+            )
+        );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
-    public function testThrowsExactly(\Closure $method, $expectedException, $expectToThrow)
-    {
+     * @dataProvider exceptionTests
+     */
+    public function testThrowsExactly(
+        \Closure $method,
+        $expectedException,
+        $expectToThrow
+    ) {
         if ($expectToThrow) {
-            $this->assertMatcherFailure('? throws exactly ?', array($method, $expectedException));
+            $this->assertMatcherFailure(
+                '? throws exactly ?',
+                array($method, $expectedException)
+            );
         } else {
-            $this->assertMatcherSuccess('? throws exactly ?', array($method, $expectedException));
+            $this->assertMatcherSuccess(
+                '? throws exactly ?',
+                array($method, $expectedException)
+            );
         }
     }
 
     /**
-	 * @dataProvider exceptionThrowsExactlyTestMessages
-	 */
-    public function testThrowsExactlyMessages(\Closure $method, $expectedException, $failureMessage)
-    {
-        $this->assertMatcherFailureMessage('? throws exactly ?', array($method, $expectedException), $failureMessage);
+     * @dataProvider exceptionThrowsExactlyTestMessages
+     */
+    public function testThrowsExactlyMessages(
+        \Closure $method,
+        $expectedException,
+        $failureMessage
+    ) {
+        $this->assertMatcherFailureMessage(
+            '? throws exactly ?',
+            array($method, $expectedException),
+            $failureMessage
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/ThrowsExceptionTest.php
+++ b/tests/Concise/Matcher/ThrowsExceptionTest.php
@@ -15,18 +15,21 @@ class ThrowsExceptionTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        $throwNothing = function () {};
-        $throwException = function () { throw new \Exception(); };
+        $throwNothing = function () {
+        };
+        $throwException = function () {
+            throw new \Exception();
+        };
 
         return array(
-            array($throwNothing,   false),
+            array($throwNothing, false),
             array($throwException, true),
         );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
+     * @dataProvider exceptionTests
+     */
     public function testThrows(\Closure $method, $expectSuccess)
     {
         try {
@@ -41,10 +44,20 @@ class ThrowsExceptionTest extends AbstractExceptionTestCase
     public function testThrowsMessage()
     {
         try {
-            $this->matcher->match('? throws exception', array(function () {}));
+            $this->matcher->match(
+                '? throws exception',
+                array(
+                    function () {
+                    }
+                )
+            );
             $this->fail("Exception was not thrown.");
         } catch (DidNotMatchException $e) {
-            $this->assert("Expected exception to be thrown.", equals, $e->getMessage());
+            $this->assert(
+                "Expected exception to be thrown.",
+                equals,
+                $e->getMessage()
+            );
         }
     }
 

--- a/tests/Concise/Matcher/ThrowsTest.php
+++ b/tests/Concise/Matcher/ThrowsTest.php
@@ -15,49 +15,89 @@ class ThrowsTest extends AbstractExceptionTestCase
 
     public function exceptionTests()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      'FAIL'),
-            array('throwNothing',        'expectMyException',    'FAIL'),
-            array('throwException',      'expectException',      'PASS'),
-            array('throwException',      'expectMyException',    'FAIL'),
-            array('throwMyException',    'expectException',      'PASS'),
-            array('throwMyException',    'expectMyException',    'PASS'),
-            array('throwMyException',    'expectOtherException', 'FAIL'),
-            array('throwOtherException', 'expectException',      'PASS'),
-            array('throwOtherException', 'expectMyException',    'FAIL'),
-            array('throwOtherException', 'expectOtherException', 'PASS'),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array('throwNothing', 'expectException', 'FAIL'),
+                array('throwNothing', 'expectMyException', 'FAIL'),
+                array('throwException', 'expectException', 'PASS'),
+                array('throwException', 'expectMyException', 'FAIL'),
+                array('throwMyException', 'expectException', 'PASS'),
+                array('throwMyException', 'expectMyException', 'PASS'),
+                array('throwMyException', 'expectOtherException', 'FAIL'),
+                array('throwOtherException', 'expectException', 'PASS'),
+                array('throwOtherException', 'expectMyException', 'FAIL'),
+                array('throwOtherException', 'expectOtherException', 'PASS'),
+            )
+        );
     }
 
     public function exceptionThrowsTestMessages()
     {
-        return $this->createExceptionTests(array(
-            array('throwNothing',        'expectException',      "Expected Exception to be thrown, but nothing was thrown."),
-            array('throwNothing',        'expectMyException',    "Expected Concise\Matcher\MyException to be thrown, but nothing was thrown."),
-            array('throwException',      'expectMyException',    "Expected Concise\Matcher\MyException to be thrown, but Exception was thrown."),
-            array('throwMyException',    'expectOtherException', "Expected Concise\Matcher\OtherException to be thrown, but Concise\Matcher\MyException was thrown."),
-            array('throwOtherException', 'expectMyException',    "Expected Concise\Matcher\MyException to be thrown, but Concise\Matcher\OtherException was thrown."),
-        ));
+        return $this->createExceptionTests(
+            array(
+                array(
+                    'throwNothing',
+                    'expectException',
+                    "Expected Exception to be thrown, but nothing was thrown."
+                ),
+                array(
+                    'throwNothing',
+                    'expectMyException',
+                    "Expected Concise\Matcher\MyException to be thrown, but nothing was thrown."
+                ),
+                array(
+                    'throwException',
+                    'expectMyException',
+                    "Expected Concise\Matcher\MyException to be thrown, but Exception was thrown."
+                ),
+                array(
+                    'throwMyException',
+                    'expectOtherException',
+                    "Expected Concise\Matcher\OtherException to be thrown, but Concise\Matcher\MyException was thrown."
+                ),
+                array(
+                    'throwOtherException',
+                    'expectMyException',
+                    "Expected Concise\Matcher\MyException to be thrown, but Concise\Matcher\OtherException was thrown."
+                ),
+            )
+        );
     }
 
     /**
-	 * @dataProvider exceptionTests
-	 */
-    public function testThrows(\Closure $method, $expectedException, $expectToThrow)
-    {
+     * @dataProvider exceptionTests
+     */
+    public function testThrows(
+        \Closure $method,
+        $expectedException,
+        $expectToThrow
+    ) {
         if ($expectToThrow) {
-            $this->assertMatcherFailure('? throws ?', array($method, $expectedException));
+            $this->assertMatcherFailure(
+                '? throws ?',
+                array($method, $expectedException)
+            );
         } else {
-            $this->assertMatcherSuccess('? throws ?', array($method, $expectedException));
+            $this->assertMatcherSuccess(
+                '? throws ?',
+                array($method, $expectedException)
+            );
         }
     }
 
     /**
-	 * @dataProvider exceptionThrowsTestMessages
-	 */
-    public function testThrowsMessages(\Closure $method, $expectedException, $failureMessage)
-    {
-        $this->assertMatcherFailureMessage('? throws ?', array($method, $expectedException), $failureMessage);
+     * @dataProvider exceptionThrowsTestMessages
+     */
+    public function testThrowsMessages(
+        \Closure $method,
+        $expectedException,
+        $failureMessage
+    ) {
+        $this->assertMatcherFailureMessage(
+            '? throws ?',
+            array($method, $expectedException),
+            $failureMessage
+        );
     }
 
     public function tags()

--- a/tests/Concise/Matcher/UrlHasPartTest.php
+++ b/tests/Concise/Matcher/UrlHasPartTest.php
@@ -16,36 +16,79 @@ class UrlHasPartTest extends AbstractMatcherTestCase
     public function data()
     {
         return array(
-            'scheme 1' => array('http://google.com', 'has scheme', 'http', true),
-            'scheme 2' => array('http://google.com', 'has scheme', 'https', false),
+            'scheme 1' => array(
+                'http://google.com',
+                'has scheme',
+                'http',
+                true
+            ),
+            'scheme 2' => array(
+                'http://google.com',
+                'has scheme',
+                'https',
+                false
+            ),
             'scheme 3' => array('google.com', 'has scheme', '', true),
-
-            'host 1' => array('http://google.com', 'has host', 'google.com', true),
-            'host 2' => array('http://google.com', 'has host', 'foo.com', false),
+            'host 1' => array(
+                'http://google.com',
+                'has host',
+                'google.com',
+                true
+            ),
+            'host 2' => array(
+                'http://google.com',
+                'has host',
+                'foo.com',
+                false
+            ),
             'host 3' => array('http://?abc', 'has host', '', true),
-
             'port 1' => array('http://foo:123', 'has port', 123, true),
             'port 2' => array('http://foo:123', 'has port', 456, false),
             'port 3' => array('http://foo:123', 'has port', 0, false),
-
             'user 1' => array('http://foo@bar', 'has user', 'foo', true),
             'user 2' => array('http://foo@bar', 'has user', 'bar', false),
             'user 3' => array('http://bar.com', 'has user', '', true),
-
-            'pass 1' => array('http://foo:baz@bar', 'has password', 'baz', true),
-            'pass 2' => array('http://foo:bar@bar', 'has password', 'baz', false),
+            'pass 1' => array(
+                'http://foo:baz@bar',
+                'has password',
+                'baz',
+                true
+            ),
+            'pass 2' => array(
+                'http://foo:bar@bar',
+                'has password',
+                'baz',
+                false
+            ),
             'pass 3' => array('http://bar.com', 'has password', '', true),
-
             'path 1' => array('http://foo.com/abc', 'has path', '/abc', true),
             'path 2' => array('http://foo.com/abc', 'has path', '/def', false),
             'path 3' => array('http://foo.com', 'has path', '', true),
-
-            'query 1' => array('http://foo.com/abc?foo', 'has query', 'foo', true),
-            'query 2' => array('http://foo.com/abc?foo', 'has query', 'bar', false),
+            'query 1' => array(
+                'http://foo.com/abc?foo',
+                'has query',
+                'foo',
+                true
+            ),
+            'query 2' => array(
+                'http://foo.com/abc?foo',
+                'has query',
+                'bar',
+                false
+            ),
             'query 3' => array('http://foo.com', 'has query', '', true),
-
-            'fragment 1' => array('http://foo.com/abc#foo', 'has fragment', 'foo', true),
-            'fragment 2' => array('http://foo.com/abc#foo', 'has fragment', 'bar', false),
+            'fragment 1' => array(
+                'http://foo.com/abc#foo',
+                'has fragment',
+                'foo',
+                true
+            ),
+            'fragment 2' => array(
+                'http://foo.com/abc#foo',
+                'has fragment',
+                'bar',
+                false
+            ),
             'fragment 3' => array('http://foo.com', 'has fragment', '', true),
         );
     }

--- a/tests/Concise/Mock/AbstractBuilderTestCase.php
+++ b/tests/Concise/Mock/AbstractBuilderTestCase.php
@@ -195,34 +195,93 @@ abstract class AbstractBuilderTestCase extends TestCase
     public function mockBuilders()
     {
         return array(
-            'mock class' => array($this->mock('\Concise\Mock\CombinationMockClass', array(1, 2)), self::MOCK_CLASS),
-            'mock abstract class' => array($this->mock('\Concise\Mock\CombinationMockAbstractClass', array(1, 2)), self::MOCK_ABSTRACT_CLASS),
-            'mock interface' => array($this->mock('\Concise\Mock\CombinationMockedInterface', array(1, 2)), self::MOCK_INTERFACE),
+            'mock class' => array(
+                $this->mock(
+                    '\Concise\Mock\CombinationMockClass',
+                    array(1, 2)
+                ),
+                self::MOCK_CLASS
+            ),
+            'mock abstract class' => array(
+                $this->mock(
+                    '\Concise\Mock\CombinationMockAbstractClass',
+                    array(1, 2)
+                ),
+                self::MOCK_ABSTRACT_CLASS
+            ),
+            'mock interface' => array(
+                $this->mock(
+                    '\Concise\Mock\CombinationMockedInterface',
+                    array(1, 2)
+                ),
+                self::MOCK_INTERFACE
+            ),
         );
     }
 
     public function niceMockBuilders()
     {
         return array(
-            'nice mock class' => array($this->niceMock('\Concise\Mock\CombinationMockClass', array(1, 2)), self::NICE_MOCK_CLASS),
-            'nice mock abstract class' => array($this->niceMock('\Concise\Mock\CombinationMockAbstractClass', array(1, 2)), self::NICE_MOCK_ABSTRACT_CLASS),
-            'partial mock' => array($this->partialMock(new CombinationMockClass(1, 2)), self::MOCK_PARTIAL),
+            'nice mock class' => array(
+                $this->niceMock(
+                    '\Concise\Mock\CombinationMockClass',
+                    array(1, 2)
+                ),
+                self::NICE_MOCK_CLASS
+            ),
+            'nice mock abstract class' => array(
+                $this->niceMock(
+                    '\Concise\Mock\CombinationMockAbstractClass',
+                    array(1, 2)
+                ),
+                self::NICE_MOCK_ABSTRACT_CLASS
+            ),
+            'partial mock' => array(
+                $this->partialMock(
+                    new CombinationMockClass(1, 2)
+                ),
+                self::MOCK_PARTIAL
+            ),
         );
     }
 
     public function abstractBuilders()
     {
         return array(
-            'mock abstract class' => array($this->mock('\Concise\Mock\CombinationMockAbstractClass', array(1, 2)), self::MOCK_ABSTRACT_CLASS),
-            'nice mock abstract class' => array($this->niceMock('\Concise\Mock\CombinationMockAbstractClass', array(1, 2)), self::NICE_MOCK_ABSTRACT_CLASS),
+            'mock abstract class' => array(
+                $this->mock(
+                    '\Concise\Mock\CombinationMockAbstractClass',
+                    array(1, 2)
+                ),
+                self::MOCK_ABSTRACT_CLASS
+            ),
+            'nice mock abstract class' => array(
+                $this->niceMock(
+                    '\Concise\Mock\CombinationMockAbstractClass',
+                    array(1, 2)
+                ),
+                self::NICE_MOCK_ABSTRACT_CLASS
+            ),
         );
     }
 
     public function finalBuilders()
     {
         return array(
-            'mock final class' => array($this->mock('\Concise\Mock\CombinationMockFinalClass', array(1, 2)), self::MOCK_FINAL_CLASS),
-            'nice mock final class' => array($this->niceMock('\Concise\Mock\CombinationMockFinalClass', array(1, 2)), self::NICE_MOCK_FINAL_CLASS),
+            'mock final class' => array(
+                $this->mock(
+                    '\Concise\Mock\CombinationMockFinalClass',
+                    array(1, 2)
+                ),
+                self::MOCK_FINAL_CLASS
+            ),
+            'nice mock final class' => array(
+                $this->niceMock(
+                    '\Concise\Mock\CombinationMockFinalClass',
+                    array(1, 2)
+                ),
+                self::NICE_MOCK_FINAL_CLASS
+            ),
         );
     }
 

--- a/tests/Concise/Mock/Action/DoActionTest.php
+++ b/tests/Concise/Mock/Action/DoActionTest.php
@@ -8,20 +8,40 @@ class DoActionTest extends TestCase
 {
     public function testMustBeATypeOfAction()
     {
-        $action = new DoAction(function () {});
-        $this->assert($action, instance_of, '\Concise\Mock\Action\AbstractAction');
+        $action = new DoAction(
+            function () {
+            }
+        );
+        $this->assert(
+            $action,
+            instance_of,
+            '\Concise\Mock\Action\AbstractAction'
+        );
     }
 
     public function testCanGeneratePHPCode()
     {
-        $action = new DoAction(function () {});
+        $action = new DoAction(
+            function () {
+            }
+        );
         $this->assert($action->getActionCode(), matches_regex, "/return/");
     }
 
     public function testWillUseDifferentCacheKeyEachTime()
     {
-        $action1 = new DoAction(function () {});
-        $action2 = new DoAction(function () {});
-        $this->assert($action1->getActionCode(), does_not_equal, $action2->getActionCode());
+        $action1 = new DoAction(
+            function () {
+            }
+        );
+        $action2 = new DoAction(
+            function () {
+            }
+        );
+        $this->assert(
+            $action1->getActionCode(),
+            does_not_equal,
+            $action2->getActionCode()
+        );
     }
 }

--- a/tests/Concise/Mock/Action/ReturnPropertyActionTest.php
+++ b/tests/Concise/Mock/Action/ReturnPropertyActionTest.php
@@ -9,6 +9,10 @@ class ReturnPropertyActionTest extends TestCase
     public function testReturnPropertyReturnsPHPCode()
     {
         $self = new ReturnPropertyAction('foo');
-        $this->assert($self->getActionCode(), contains_string, 'return $this->foo;');
+        $this->assert(
+            $self->getActionCode(),
+            contains_string,
+            'return $this->foo;'
+        );
     }
 }

--- a/tests/Concise/Mock/ArgumentMatcherTest.php
+++ b/tests/Concise/Mock/ArgumentMatcherTest.php
@@ -34,8 +34,7 @@ class ArgumentMatcherTest extends TestCase
         $this->assert($this->matcher->match(array(0), array(false)), is_true);
     }
 
-    public function testMatchingMoreThanOneItemWhereOnlyOneIsDifferentReturnsFalse(
-    )
+    public function testMatchingMoreThanOneItemWhereOnlyOneIsDifferentReturnsFalse()
     {
         $this->assert(
             $this->matcher->match(array('a', 'b'), array('a', 'a')),

--- a/tests/Concise/Mock/ArgumentMatcherTest.php
+++ b/tests/Concise/Mock/ArgumentMatcherTest.php
@@ -34,13 +34,20 @@ class ArgumentMatcherTest extends TestCase
         $this->assert($this->matcher->match(array(0), array(false)), is_true);
     }
 
-    public function testMatchingMoreThanOneItemWhereOnlyOneIsDifferentReturnsFalse()
+    public function testMatchingMoreThanOneItemWhereOnlyOneIsDifferentReturnsFalse(
+    )
     {
-        $this->assert($this->matcher->match(array('a', 'b'), array('a', 'a')), is_false);
+        $this->assert(
+            $this->matcher->match(array('a', 'b'), array('a', 'a')),
+            is_false
+        );
     }
 
     public function testExpectedIsAllowedToContainAnythingConstant()
     {
-        $this->assert($this->matcher->match(array('a', self::ANYTHING), array('a', 'a')), is_true);
+        $this->assert(
+            $this->matcher->match(array('a', self::ANYTHING), array('a', 'a')),
+            is_true
+        );
     }
 }

--- a/tests/Concise/Mock/BuilderAbstractTest.php
+++ b/tests/Concise/Mock/BuilderAbstractTest.php
@@ -10,54 +10,56 @@ class BuilderAbstractTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMockAbstractClassesThatDoNotHaveRulesForAllMethodsWillStillOperate(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')
-            ->get();
+    public function testMockAbstractClassesThatDoNotHaveRulesForAllMethodsWillStillOperate(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->get();
         $this->assert($mock->myMethod(), is_null);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testNiceMockAbstractClassesThatDoNotHaveRulesForAllMethodsWillStillOperate(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')
-            ->get();
+    public function testNiceMockAbstractClassesThatDoNotHaveRulesForAllMethodsWillStillOperate(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->get();
         $this->assert($mock->myMethod(), is_null);
     }
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage myAbstractMethod() is abstract and has no associated action
+     * @expectedExceptionMessage myAbstractMethod() is abstract and has no
+     *     associated action
      * @dataProvider abstractBuilders
      */
-    public function testCallingAnAbstractMethodWithNoRuleThrowsException(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')
-            ->get();
+    public function testCallingAnAbstractMethodWithNoRuleThrowsException(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->get();
         $mock->myAbstractMethod();
     }
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage myAbstractMethod() is abstract and has no associated action
+     * @expectedExceptionMessage myAbstractMethod() is abstract and has no
+     *     associated action
      * @dataProvider abstractBuilders
      */
-    public function testCallingAnAbstractMethodOnANiceMockWithNoRuleThrowsException(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')
-            ->get();
+    public function testCallingAnAbstractMethodOnANiceMockWithNoRuleThrowsException(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->get();
         $mock->myAbstractMethod();
     }
 
     /**
      * @dataProvider abstractBuilders
      */
-    public function testAbstractMethodsCanHaveRulesAttached(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myAbstractMethod')
-            ->get();
+    public function testAbstractMethodsCanHaveRulesAttached(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myAbstractMethod')->get();
         $this->assert($mock->myAbstractMethod(), is_null);
     }
 }

--- a/tests/Concise/Mock/BuilderAnythingTest.php
+++ b/tests/Concise/Mock/BuilderAnythingTest.php
@@ -12,7 +12,10 @@ class BuilderAnythingTest extends AbstractBuilderTestCase
      */
     public function testWithParameterCanAcceptAnything(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod')->with(self::ANYTHING)->andReturn('foo')->get();
+        $mock = $builder->expect('myMethod')
+            ->with(self::ANYTHING)
+            ->andReturn('foo')
+            ->get();
         $this->assert($mock->myMethod(null), equals, 'foo');
     }
 
@@ -21,7 +24,10 @@ class BuilderAnythingTest extends AbstractBuilderTestCase
      */
     public function testWithParameterCanAcceptAnythingElse(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod')->with(self::ANYTHING)->andReturn('foo')->get();
+        $mock = $builder->expect('myMethod')
+            ->with(self::ANYTHING)
+            ->andReturn('foo')
+            ->get();
         $this->assert($mock->myMethod(123), equals, 'foo');
     }
 }

--- a/tests/Concise/Mock/BuilderConstructorTest.php
+++ b/tests/Concise/Mock/BuilderConstructorTest.php
@@ -10,12 +10,18 @@ class BuilderConstructorTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMocksCanHaveTheirConstructorDisabled(MockBuilder $builder, $type)
-    {
+    public function testMocksCanHaveTheirConstructorDisabled(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
-            $this->expectFailure('You cannot disable the constructor of an interface (\Concise\Mock\CombinationMockedInterface).');
+            $this->expectFailure(
+                'You cannot disable the constructor of an interface (\Concise\Mock\CombinationMockedInterface).'
+            );
         } elseif (self::MOCK_PARTIAL === $type) {
-            $this->expectFailure('You cannot disable the constructor on a partial mock because any constructor would have already run (Concise\Mock\CombinationMockClass).');
+            $this->expectFailure(
+                'You cannot disable the constructor on a partial mock because any constructor would have already run (Concise\Mock\CombinationMockClass).'
+            );
         }
         $mock = $builder->disableConstructor()->get();
         $this->assert($mock->constructorRun, is_false);
@@ -24,8 +30,10 @@ class BuilderConstructorTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMockReceivesConstructorArguments(MockBuilder $builder, $type)
-    {
+    public function testMockReceivesConstructorArguments(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             return $this->notApplicable();
         }

--- a/tests/Concise/Mock/BuilderCustomClassNameTest.php
+++ b/tests/Concise/Mock/BuilderCustomClassNameTest.php
@@ -12,8 +12,9 @@ class BuilderCustomClassNameTest extends AbstractBuilderTestCase
      * @expectedExceptionMessage Invalid class name 'Concise\Mock\123'.
      * @dataProvider allBuilders
      */
-    public function testWillThrowExceptionIfTheCustomNameIsNotValid(MockBuilder $builder)
-    {
+    public function testWillThrowExceptionIfTheCustomNameIsNotValid(
+        MockBuilder $builder
+    ) {
         $builder->setCustomClassName('123')->get();
     }
 

--- a/tests/Concise/Mock/BuilderDoTest.php
+++ b/tests/Concise/Mock/BuilderDoTest.php
@@ -12,8 +12,10 @@ class BuilderDoTest extends AbstractBuilderTestCase
      */
     public function testACallbackCanBeSet(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andDo(function () {})
-            ->get();
+        $mock = $builder->stub('myMethod')->andDo(
+            function () {
+            }
+        )->get();
         $this->assert($mock->myMethod(), equals, null);
     }
 
@@ -23,10 +25,11 @@ class BuilderDoTest extends AbstractBuilderTestCase
     public function testTheCallbackWillBeExecuted(MockBuilder $builder)
     {
         $a = 123;
-        $mock = $builder->stub('myMethod')->andDo(function () use (&$a) {
-                    $a = 456;
-                })
-            ->get();
+        $mock = $builder->stub('myMethod')->andDo(
+            function () use (&$a) {
+                $a = 456;
+            }
+        )->get();
         $mock->myMethod();
         $this->assert($a, equals, 456);
     }
@@ -34,13 +37,15 @@ class BuilderDoTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testTheCallbackWillNotBeExecutedIfNotCalled(MockBuilder $builder)
-    {
+    public function testTheCallbackWillNotBeExecutedIfNotCalled(
+        MockBuilder $builder
+    ) {
         $a = 123;
-        $builder->stub('myMethod')->andDo(function () use (&$a) {
-                    $a = 456;
-                })
-            ->get();
+        $builder->stub('myMethod')->andDo(
+            function () use (&$a) {
+                $a = 456;
+            }
+        )->get();
         $this->assert($a, equals, 123);
     }
 
@@ -48,12 +53,14 @@ class BuilderDoTest extends AbstractBuilderTestCase
      * @group #182
      * @dataProvider allBuilders
      */
-    public function testAndDoWillBeProvidedACountThatStartsAt1(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andDo(function (InvocationInterface $i) {
-                    return $i->getInvokeCount();
-                })
-            ->get();
+    public function testAndDoWillBeProvidedACountThatStartsAt1(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andDo(
+            function (InvocationInterface $i) {
+                return $i->getInvokeCount();
+            }
+        )->get();
         $this->assert($mock->myMethod(), equals, 1);
     }
 
@@ -61,13 +68,15 @@ class BuilderDoTest extends AbstractBuilderTestCase
      * @group #182
      * @dataProvider allBuilders
      */
-    public function testAndDoWillBeProvidedACountThatIncrementsWithInvocations(MockBuilder $builder)
-    {
+    public function testAndDoWillBeProvidedACountThatIncrementsWithInvocations(
+        MockBuilder $builder
+    ) {
         $c = 0;
-        $mock = $builder->stub('myMethod')->andDo(function (InvocationInterface $i) use (&$c) {
-                    $c = $i->getInvokeCount();
-                })
-            ->get();
+        $mock = $builder->stub('myMethod')->andDo(
+            function (InvocationInterface $i) use (&$c) {
+                $c = $i->getInvokeCount();
+            }
+        )->get();
         $mock->myMethod();
         $mock->myMethod();
         $this->assert($c, equals, 2);
@@ -77,13 +86,15 @@ class BuilderDoTest extends AbstractBuilderTestCase
      * @group #182
      * @dataProvider allBuilders
      */
-    public function testAndDoWillBeProvidedWithOriginalArgs(MockBuilder $builder)
-    {
+    public function testAndDoWillBeProvidedWithOriginalArgs(
+        MockBuilder $builder
+    ) {
         $a = array();
-        $mock = $builder->stub('myMethod')->andDo(function (InvocationInterface $i) use (&$a) {
-                    $a = $i->getArguments();
-                })
-            ->get();
+        $mock = $builder->stub('myMethod')->andDo(
+            function (InvocationInterface $i) use (&$a) {
+                $a = $i->getArguments();
+            }
+        )->get();
         $mock->myMethod('hello');
         $this->assert($a, equals, array('hello'));
     }

--- a/tests/Concise/Mock/BuilderExpectTest.php
+++ b/tests/Concise/Mock/BuilderExpectTest.php
@@ -28,31 +28,33 @@ class BuilderExpectTest extends AbstractBuilderTestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage You cannot assign an action to 'myMethod()' when it is never expected.
+     * @expectedExceptionMessage You cannot assign an action to 'myMethod()'
+     *     when it is never expected.
      * @dataProvider allBuilders
      */
-    public function testAddingAnActionOntoAMethodThatIsNeverExpectedThrowsException(MockBuilder $builder)
-    {
-        $builder->expect('myMethod')->never()->andReturn(null)
-            ->get();
+    public function testAddingAnActionOntoAMethodThatIsNeverExpectedThrowsException(
+        MockBuilder $builder
+    ) {
+        $builder->expect('myMethod')->never()->andReturn(null)->get();
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testWeDoNotNeedToSpecifyAnActionForAnExpectationWeNeverWantToHappen(MockBuilder $builder)
-    {
-        $builder->expect('myMethod')->never()
-            ->get();
+    public function testWeDoNotNeedToSpecifyAnActionForAnExpectationWeNeverWantToHappen(
+        MockBuilder $builder
+    ) {
+        $builder->expect('myMethod')->never()->get();
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testCanCreateAnExpectationOfASpecificAmountOfTimes(MockBuilder $builder)
-    {
-        $mock = $builder->expect('myMethod')->exactly(3)->andReturn(null)
-            ->get();
+    public function testCanCreateAnExpectationOfASpecificAmountOfTimes(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->expect('myMethod')->exactly(3)->andReturn(null)->get();
         $mock->myMethod();
         $mock->myMethod();
         $mock->myMethod();
@@ -63,8 +65,7 @@ class BuilderExpectTest extends AbstractBuilderTestCase
      */
     public function testExactlyZeroIsTheSameAsNever(MockBuilder $builder)
     {
-        $builder->expect('myMethod')->exactly(0)
-            ->get();
+        $builder->expect('myMethod')->exactly(0)->get();
     }
 
     /**
@@ -72,18 +73,18 @@ class BuilderExpectTest extends AbstractBuilderTestCase
      */
     public function testDefaultExpectationIsOnce(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod')->andReturn(null)
-            ->get();
+        $mock = $builder->expect('myMethod')->andReturn(null)->get();
         $mock->myMethod();
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testCanCreateAnExpectationWithArgumentValues(MockBuilder $builder)
-    {
-        $mock = $builder->expect('myMethod')->with('foo')->andReturn('bar')
-            ->get();
+    public function testCanCreateAnExpectationWithArgumentValues(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->expect('myMethod')->with('foo')->andReturn('bar')->get();
         $this->assert($mock->myMethod('foo'), equals, 'bar');
     }
 
@@ -92,8 +93,7 @@ class BuilderExpectTest extends AbstractBuilderTestCase
      */
     public function testCanUseExpectsInsteadOfExpect(MockBuilder $builder)
     {
-        $mock = $builder->expects('myMethod')
-            ->get();
+        $mock = $builder->expects('myMethod')->get();
         $mock->myMethod();
     }
 
@@ -102,8 +102,7 @@ class BuilderExpectTest extends AbstractBuilderTestCase
      */
     public function testExpectWithMultipleArguments(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod', 'mySecondMethod')
-            ->get();
+        $mock = $builder->expect('myMethod', 'mySecondMethod')->get();
         $mock->myMethod();
         $mock->mySecondMethod();
     }
@@ -113,8 +112,7 @@ class BuilderExpectTest extends AbstractBuilderTestCase
      */
     public function testExpectsWithMultipleArguments(MockBuilder $builder)
     {
-        $mock = $builder->expects('myMethod', 'mySecondMethod')
-            ->get();
+        $mock = $builder->expects('myMethod', 'mySecondMethod')->get();
         $mock->myMethod();
         $mock->mySecondMethod();
     }
@@ -122,9 +120,9 @@ class BuilderExpectTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMultipleExpectsThatAreNeverExpected(MockBuilder $builder)
-    {
-        $builder->expect('myWithMethod', 'myMethod')->never()
-            ->get();
+    public function testMultipleExpectsThatAreNeverExpected(
+        MockBuilder $builder
+    ) {
+        $builder->expect('myWithMethod', 'myMethod')->never()->get();
     }
 }

--- a/tests/Concise/Mock/BuilderExposeTest.php
+++ b/tests/Concise/Mock/BuilderExposeTest.php
@@ -13,7 +13,9 @@ class BuilderExposeTest extends AbstractBuilderTestCase
             case self::MOCK_INTERFACE:
             case self::MOCK_CLASS:
             case self::MOCK_ABSTRACT_CLASS:
-                $this->expectFailure("You cannot expose a method on a mock that is not nice.");
+                $this->expectFailure(
+                    "You cannot expose a method on a mock that is not nice."
+                );
         }
     }
 
@@ -24,8 +26,7 @@ class BuilderExposeTest extends AbstractBuilderTestCase
     public function testExposeASingleMethod(MockBuilder $builder, $type)
     {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
-        $mock = $builder->expose('mySecretMethod')
-            ->get();
+        $mock = $builder->expose('mySecretMethod')->get();
         $this->assert($mock->myMethod(), equals, 'abc');
     }
 
@@ -35,22 +36,24 @@ class BuilderExposeTest extends AbstractBuilderTestCase
      * @group #189
      * @dataProvider allBuilders
      */
-    public function testAnExceptionIsThrownIfTheMethodDoesNotExist(MockBuilder $builder, $type)
-    {
+    public function testAnExceptionIsThrownIfTheMethodDoesNotExist(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
-        $builder->expose('baz')
-            ->get();
+        $builder->expose('baz')->get();
     }
 
     /**
      * @group #189
      * @dataProvider allBuilders
      */
-    public function testExposeTwoMethodsWithSeparateParameters(MockBuilder $builder, $type)
-    {
+    public function testExposeTwoMethodsWithSeparateParameters(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
-        $mock = $builder->expose('myMethod', 'mySecondMethod')
-            ->get();
+        $mock = $builder->expose('myMethod', 'mySecondMethod')->get();
         $this->assert($mock->mySecondMethod(), equals, 'bar');
     }
 
@@ -58,11 +61,12 @@ class BuilderExposeTest extends AbstractBuilderTestCase
      * @group #189
      * @dataProvider allBuilders
      */
-    public function testExposeTwoMethodsByCallingExposeTwice(MockBuilder $builder, $type)
-    {
+    public function testExposeTwoMethodsByCallingExposeTwice(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
-        $mock = $builder->expose('myMethod')->expose('mySecondMethod')
-            ->get();
+        $mock = $builder->expose('myMethod')->expose('mySecondMethod')->get();
         $this->assert($mock->myMethod(), equals, 'abc');
     }
 
@@ -70,11 +74,12 @@ class BuilderExposeTest extends AbstractBuilderTestCase
      * @group #189
      * @dataProvider allBuilders
      */
-    public function testExposeTwoMethodsWithArraySyntax(MockBuilder $builder, $type)
-    {
+    public function testExposeTwoMethodsWithArraySyntax(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
-        $mock = $builder->expose(array('myMethod', 'mySecondMethod'))
-            ->get();
+        $mock = $builder->expose(array('myMethod', 'mySecondMethod'))->get();
         $this->assert($mock->mySecondMethod(), equals, 'bar');
     }
 
@@ -92,8 +97,10 @@ class BuilderExposeTest extends AbstractBuilderTestCase
      * @group #189
      * @dataProvider allBuilders
      */
-    public function testExposeAllMethodsWillExposeAllMethods(MockBuilder $builder, $type)
-    {
+    public function testExposeAllMethodsWillExposeAllMethods(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->youCannotExposeAMethodOnAMockThatIsNotNice($type);
         $mock = $builder->exposeAll()->get();
         $this->assert($mock->mySecretMethod(), equals, 'abc');

--- a/tests/Concise/Mock/BuilderFinalTest.php
+++ b/tests/Concise/Mock/BuilderFinalTest.php
@@ -26,7 +26,6 @@ class BuilderFinalTest extends AbstractBuilderTestCase
      */
     public function testFinalMethodsCanNotBeMocked(MockBuilder $builder)
     {
-        $builder->stub('myFinalMethod')
-            ->get();
+        $builder->stub('myFinalMethod')->get();
     }
 }

--- a/tests/Concise/Mock/BuilderGeneralTest.php
+++ b/tests/Concise/Mock/BuilderGeneralTest.php
@@ -10,8 +10,9 @@ class BuilderGeneralTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMockCanBeCreatedFromAnObjectThatExists(MockBuilder $builder)
-    {
+    public function testMockCanBeCreatedFromAnObjectThatExists(
+        MockBuilder $builder
+    ) {
         $mock = $builder->get();
         $this->assert($mock, instance_of, $builder->getClassName());
     }
@@ -19,11 +20,17 @@ class BuilderGeneralTest extends AbstractBuilderTestCase
     /**
      * @dataProvider mockBuilders
      */
-    public function testCallingMethodThatHasNoAssociatedActionWillThrowAnException(MockBuilder $builder, $type)
-    {
-        $this->expectFailure("myMethod() does not have an associated action - consider a niceMock()?");
+    public function testCallingMethodThatHasNoAssociatedActionWillThrowAnException(
+        MockBuilder $builder,
+        $type
+    ) {
+        $this->expectFailure(
+            "myMethod() does not have an associated action - consider a niceMock()?"
+        );
         if (self::MOCK_INTERFACE === $type) {
-            $this->expectFailure("myMethod() is abstract and has no associated action.");
+            $this->expectFailure(
+                "myMethod() is abstract and has no associated action."
+            );
         }
         $mock = $builder->get();
         $mock->myMethod();
@@ -32,8 +39,9 @@ class BuilderGeneralTest extends AbstractBuilderTestCase
     /**
      * @dataProvider niceMockBuilders
      */
-    public function testCallingMethodThatHasNoAssociatedActionOnANiceMockWillUseOriginal(MockBuilder $builder)
-    {
+    public function testCallingMethodThatHasNoAssociatedActionOnANiceMockWillUseOriginal(
+        MockBuilder $builder
+    ) {
         $mock = $builder->get();
         $this->assert($mock->myMethod(), equals, 'abc');
     }
@@ -50,7 +58,8 @@ class BuilderGeneralTest extends AbstractBuilderTestCase
     /**
      * @group #129
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot create a nice mock of an interface (\Concise\Mock\CombinationMockedInterface)
+     * @expectedExceptionMessage You cannot create a nice mock of an interface
+     *     (\Concise\Mock\CombinationMockedInterface)
      */
     public function testCannotCreateANiceMockOfAnInterface()
     {

--- a/tests/Concise/Mock/BuilderPrivateTest.php
+++ b/tests/Concise/Mock/BuilderPrivateTest.php
@@ -12,12 +12,13 @@ class BuilderPrivateTest extends AbstractBuilderTestCase
      * @expectedExceptionMessage cannot be mocked because it it private.
      * @dataProvider allBuilders
      */
-    public function testMockingPrivateMethodWillThrowException(MockBuilder $builder, $type)
-    {
+    public function testMockingPrivateMethodWillThrowException(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure('does not exist.');
         }
-        $builder->stub(array('myPrivateMethod' => 'bar'))
-            ->get();
+        $builder->stub(array('myPrivateMethod' => 'bar'))->get();
     }
 }

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -52,8 +52,10 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
      * @group #182
      * @dataProvider allBuilders
      */
-    public function testSetAPrivatePropertyOnAMockWillSetThePropertyOnTheNonMockedClass(MockBuilder $builder, $type)
-    {
+    public function testSetAPrivatePropertyOnAMockWillSetThePropertyOnTheNonMockedClass(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface");
         }
@@ -66,8 +68,10 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
      * @group #199
      * @dataProvider allBuilders
      */
-    public function testSettingAPropertyWhenCreatingAMockReturnsSelfForChaining(MockBuilder $builder, $type)
-    {
+    public function testSettingAPropertyWhenCreatingAMockReturnsSelfForChaining(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface.");
         }
@@ -96,7 +100,10 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface.");
         }
-        $mock = $builder->setProperty('property1', 'a')->setProperty('property2', 'b')->get();
+        $mock = $builder->setProperty('property1', 'a')->setProperty(
+            'property2',
+            'b'
+        )->get();
         $this->verify($mock->property1, equals, 'a');
         $this->verify($mock->property2, equals, 'b');
     }
@@ -105,8 +112,10 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
      * @group #199
      * @dataProvider allBuilders
      */
-    public function testSettingPropertiesWhenCreatingAMockReturnsSelfForChaining(MockBuilder $builder, $type)
-    {
+    public function testSettingPropertiesWhenCreatingAMockReturnsSelfForChaining(
+        MockBuilder $builder,
+        $type
+    ) {
         $this->assert($builder->setProperties(array()), equals, $builder);
     }
 
@@ -114,15 +123,19 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
      * @group #199
      * @dataProvider allBuilders
      */
-    public function testSettingMultiplePropertiesInOneStatement(MockBuilder $builder, $type)
-    {
+    public function testSettingMultiplePropertiesInOneStatement(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface.");
         }
-        $mock = $builder->setProperties(array(
+        $mock = $builder->setProperties(
+            array(
                 'property1' => 'a',
                 'property2' => 'b',
-            ))->get();
+            )
+        )->get();
         $this->verify($mock->property1, equals, 'a');
         $this->verify($mock->property2, equals, 'b');
     }
@@ -131,15 +144,18 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
      * @group #199
      * @dataProvider allBuilders
      */
-    public function testSettingMultiplePropertiesInOneStatementWillNotOverrideOtherPropertiesSet(MockBuilder $builder, $type)
-    {
+    public function testSettingMultiplePropertiesInOneStatementWillNotOverrideOtherPropertiesSet(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface.");
         }
-        $mock = $builder->setProperty('property1', 'a')
-            ->setProperties(array(
-                'property2' => 'b',
-            ))->get();
+        $mock = $builder->setProperty('property1', 'a')->setProperties(
+                array(
+                    'property2' => 'b',
+                )
+            )->get();
         $this->verify($mock->property1, equals, 'a');
         $this->verify($mock->property2, equals, 'b');
     }
@@ -158,27 +174,33 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testSetAProtectedPropertyWhenCreatingTheMock(MockBuilder $builder, $type)
-    {
+    public function testSetAProtectedPropertyWhenCreatingTheMock(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface");
         }
-        $mock = $builder->setProperty('hidden', 'bar')
-            ->get();
+        $mock = $builder->setProperty('hidden', 'bar')->get();
         $this->assert($this->getProperty($mock, 'hidden'), equals, 'bar');
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testSetAPropertyThatDoesNotExistIsPermitted(MockBuilder $builder, $type)
-    {
+    public function testSetAPropertyThatDoesNotExistIsPermitted(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface");
         }
-        $mock = $builder->setProperty('does_not_exist', 'bar')
-            ->get();
-        $this->assert($this->getProperty($mock, 'does_not_exist'), equals, 'bar');
+        $mock = $builder->setProperty('does_not_exist', 'bar')->get();
+        $this->assert(
+            $this->getProperty($mock, 'does_not_exist'),
+            equals,
+            'bar'
+        );
     }
 
     /**
@@ -189,14 +211,17 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
         if (self::MOCK_INTERFACE === $type) {
             $this->expectFailure("You cannot set a property on an interface");
         }
-        $mock = $builder->setProperty('does_not_exist', null)
-            ->get();
+        $mock = $builder->setProperty('does_not_exist', null)->get();
         $this->assert($this->getProperty($mock, 'does_not_exist'), is_null);
     }
 
     public function testPropertiesAreAlwaysFoundIfClassHasMagicGet()
     {
-        $this->assert($this->getProperty(new MagicProperty(), 'does_not_exist'), equals, 'not_found');
+        $this->assert(
+            $this->getProperty(new MagicProperty(), 'does_not_exist'),
+            equals,
+            'not_found'
+        );
     }
 
     public function testPropertiesAreAlwaysSetIfClassHasMagicSet()

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -152,10 +152,10 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
             $this->expectFailure("You cannot set a property on an interface.");
         }
         $mock = $builder->setProperty('property1', 'a')->setProperties(
-                array(
-                    'property2' => 'b',
-                )
-            )->get();
+            array(
+                'property2' => 'b',
+            )
+        )->get();
         $this->verify($mock->property1, equals, 'a');
         $this->verify($mock->property2, equals, 'b');
     }

--- a/tests/Concise/Mock/BuilderReturnCallbackTest.php
+++ b/tests/Concise/Mock/BuilderReturnCallbackTest.php
@@ -12,57 +12,67 @@ class BuilderReturnCallbackTest extends AbstractBuilderTestCase
      */
     public function testAReturnCallbackCanBeSet(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andReturnCallback(function () {})
-            ->get();
+        $mock = $builder->stub('myMethod')->andReturnCallback(
+            function () {
+            }
+        )->get();
         $this->assert($mock->myMethod(), is_null);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testAReturnCallbackWillBeEvaluatedForItsReturnValue(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturnCallback(function () {
-                    return 'foo';
-                })
-            ->get();
+    public function testAReturnCallbackWillBeEvaluatedForItsReturnValue(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturnCallback(
+            function () {
+                return 'foo';
+            }
+        )->get();
         $this->assert($mock->myMethod(), equals, 'foo');
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testAReturnCallbackMustNotBeExecutedIfTheMethodWasNeverInvoked(MockBuilder $builder)
-    {
+    public function testAReturnCallbackMustNotBeExecutedIfTheMethodWasNeverInvoked(
+        MockBuilder $builder
+    ) {
         $count = 0;
-        $builder->stub('myMethod')->andReturnCallback(function () use (&$count) {
-                    ++$count;
-                })
-            ->get();
+        $builder->stub('myMethod')->andReturnCallback(
+            function () use (&$count) {
+                ++$count;
+            }
+        )->get();
         $this->assert($count, equals, 0);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testAReturnCallbackWillBeProvidedACountThatStartsAt1(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturnCallback(function (InvocationInterface $i) {
-                    return $i->getInvokeCount();
-                })
-            ->get();
+    public function testAReturnCallbackWillBeProvidedACountThatStartsAt1(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturnCallback(
+            function (InvocationInterface $i) {
+                return $i->getInvokeCount();
+            }
+        )->get();
         $this->assert($mock->myMethod(), equals, 1);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testAReturnCallbackWillBeProvidedACountThatIncrementsWithInvocations(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturnCallback(function (InvocationInterface $i) {
-                    return $i->getInvokeCount();
-                })
-            ->get();
+    public function testAReturnCallbackWillBeProvidedACountThatIncrementsWithInvocations(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturnCallback(
+            function (InvocationInterface $i) {
+                return $i->getInvokeCount();
+            }
+        )->get();
         $mock->myMethod();
         $this->assert($mock->myMethod(), equals, 2);
     }
@@ -70,12 +80,14 @@ class BuilderReturnCallbackTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testAReturnCallbackWillBeProvidedWithOriginalArgs(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturnCallback(function (InvocationInterface $i) {
-                    return $i->getArguments();
-                })
-            ->get();
+    public function testAReturnCallbackWillBeProvidedWithOriginalArgs(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturnCallback(
+            function (InvocationInterface $i) {
+                return $i->getArguments();
+            }
+        )->get();
         $this->assert($mock->myMethod('hello'), equals, array('hello'));
     }
 }

--- a/tests/Concise/Mock/BuilderReturnPropertyTest.php
+++ b/tests/Concise/Mock/BuilderReturnPropertyTest.php
@@ -36,8 +36,7 @@ class BuilderReturnPropertyTest extends AbstractBuilderTestCase
             );
         }
         $mock =
-            $builder->stub('myMethod')->andReturnProperty('doesnt_exist')->get(
-            );
+            $builder->stub('myMethod')->andReturnProperty('doesnt_exist')->get();
         $mock->myMethod();
     }
 }

--- a/tests/Concise/Mock/BuilderReturnPropertyTest.php
+++ b/tests/Concise/Mock/BuilderReturnPropertyTest.php
@@ -13,7 +13,9 @@ class BuilderReturnPropertyTest extends AbstractBuilderTestCase
     public function testAReturnPropertyCanBeSet(MockBuilder $builder, $type)
     {
         if (self::MOCK_INTERFACE === $type) {
-            $this->expectFailure("You cannot return a property from an interface (\Concise\Mock\CombinationMockedInterface).");
+            $this->expectFailure(
+                "You cannot return a property from an interface (\Concise\Mock\CombinationMockedInterface)."
+            );
         }
         $mock = $builder->stub('myMethod')->andReturnProperty('hidden')->get();
         $this->assert($mock->myMethod(), equals, 'foo');
@@ -24,12 +26,18 @@ class BuilderReturnPropertyTest extends AbstractBuilderTestCase
      * @expectedExceptionMessage Property 'doesnt_exist' does not exist for
      * @dataProvider allBuilders
      */
-    public function testAnExceptionIsThrownIfPropertyDoesNotExistAtRuntime(MockBuilder $builder, $type)
-    {
+    public function testAnExceptionIsThrownIfPropertyDoesNotExistAtRuntime(
+        MockBuilder $builder,
+        $type
+    ) {
         if (self::MOCK_INTERFACE === $type) {
-            $this->expectFailure("You cannot return a property from an interface (\Concise\Mock\CombinationMockedInterface).");
+            $this->expectFailure(
+                "You cannot return a property from an interface (\Concise\Mock\CombinationMockedInterface)."
+            );
         }
-        $mock = $builder->stub('myMethod')->andReturnProperty('doesnt_exist')->get();
+        $mock =
+            $builder->stub('myMethod')->andReturnProperty('doesnt_exist')->get(
+            );
         $mock->myMethod();
     }
 }

--- a/tests/Concise/Mock/BuilderReturnSelfTest.php
+++ b/tests/Concise/Mock/BuilderReturnSelfTest.php
@@ -12,8 +12,7 @@ class BuilderReturnSelfTest extends AbstractBuilderTestCase
      */
     public function testMethodsCanReturnSelf(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andReturnSelf()
-            ->get();
+        $mock = $builder->stub('myMethod')->andReturnSelf()->get();
         $this->assert($mock->myMethod(), is_the_same_as, $mock);
     }
 }

--- a/tests/Concise/Mock/BuilderReturnTest.php
+++ b/tests/Concise/Mock/BuilderReturnTest.php
@@ -12,8 +12,7 @@ class BuilderReturnTest extends AbstractBuilderTestCase
      */
     public function testAndReturnWithASingleArgument(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andReturn('foo')
-            ->get();
+        $mock = $builder->stub('myMethod')->andReturn('foo')->get();
         $this->assert($mock->myMethod(), equals, 'foo');
     }
 
@@ -22,18 +21,17 @@ class BuilderReturnTest extends AbstractBuilderTestCase
      */
     public function testAndReturnCanTakeMultipleArguments(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')
-            ->get();
+        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')->get();
         $this->assert($mock->myMethod(), equals, 'foo');
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testAndReturnWithMultipleArgumentsCanBeCalledWithDifferentResults(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')
-            ->get();
+    public function testAndReturnWithMultipleArgumentsCanBeCalledWithDifferentResults(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')->get();
         $mock->myMethod();
         $this->assert($mock->myMethod(), equals, 'bar');
     }
@@ -41,10 +39,10 @@ class BuilderReturnTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testAndReturnWithASingleArgumentWillAlwaysReturnThatValue(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturn('foo')
-            ->get();
+    public function testAndReturnWithASingleArgumentWillAlwaysReturnThatValue(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturn('foo')->get();
         $mock->myMethod();
         $mock->myMethod();
         $this->assert($mock->myMethod(), equals, 'foo');
@@ -55,10 +53,10 @@ class BuilderReturnTest extends AbstractBuilderTestCase
      * @expectedExceptionMessage Only 2 return values have been provided.
      * @dataProvider allBuilders
      */
-    public function testAndReturnWithMultipleArgumentsCanNotBeCalledMoreTimesThatReturnValues(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')
-            ->get();
+    public function testAndReturnWithMultipleArgumentsCanNotBeCalledMoreTimesThatReturnValues(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturn('foo', 'bar')->get();
         $mock->myMethod();
         $mock->myMethod();
         $mock->myMethod();

--- a/tests/Concise/Mock/BuilderStaticTest.php
+++ b/tests/Concise/Mock/BuilderStaticTest.php
@@ -12,8 +12,7 @@ class BuilderStaticTest extends AbstractBuilderTestCase
      */
     public function testMocksCanMockStaticMethods(MockBuilder $builder)
     {
-        $mock = $builder->stub(array('myStaticMethod' => 'foo'))
-            ->get();
+        $mock = $builder->stub(array('myStaticMethod' => 'foo'))->get();
         $this->assert($mock->myStaticMethod(), equals, 'foo');
     }
 }

--- a/tests/Concise/Mock/BuilderStubTest.php
+++ b/tests/Concise/Mock/BuilderStubTest.php
@@ -12,30 +12,32 @@ class BuilderStubTest extends AbstractBuilderTestCase
      */
     public function testCanStubMethodWithAssociativeArray(MockBuilder $builder)
     {
-        $mock = $builder->stub(array('myMethod' => 123))
-            ->get();
+        $mock = $builder->stub(array('myMethod' => 123))->get();
         $this->assert($mock->myMethod(), equals, 123);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testStubbingWithAnArrayCanCreateMultipleStubs(MockBuilder $builder)
-    {
-        $mock = $builder->stub(array('myMethod' => 123, 'mySecondMethod' => 'bar'))
-            ->get();
+    public function testStubbingWithAnArrayCanCreateMultipleStubs(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub(array('myMethod' => 123, 'mySecondMethod' => 'bar'))
+                ->get();
         $this->assert($mock->mySecondMethod(), equals, 'bar');
     }
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage stub() called with array must have at least 1 element.
+     * @expectedExceptionMessage stub() called with array must have at least 1
+     *     element.
      * @dataProvider allBuilders
      */
-    public function testStubbingWithAnArrayMustHaveMoreThanZeroElements(MockBuilder $builder)
-    {
-        $builder->stub(array())
-            ->get();
+    public function testStubbingWithAnArrayMustHaveMoreThanZeroElements(
+        MockBuilder $builder
+    ) {
+        $builder->stub(array())->get();
     }
 
     /**
@@ -43,18 +45,17 @@ class BuilderStubTest extends AbstractBuilderTestCase
      */
     public function testCallingMethodOnNiceMockWithStub(MockBuilder $builder)
     {
-        $mock = $builder->stub(array('myMethod' => 123))
-            ->get();
+        $mock = $builder->stub(array('myMethod' => 123))->get();
         $this->assert($mock->myMethod(), equals, 123);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testStubsCanBeCreatedByChainingAnAction(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod')->andReturn(123)
-            ->get();
+    public function testStubsCanBeCreatedByChainingAnAction(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod')->andReturn(123)->get();
         $this->assert($mock->myMethod(), equals, 123);
     }
 
@@ -63,8 +64,7 @@ class BuilderStubTest extends AbstractBuilderTestCase
      */
     public function testStubWithNoActionWillReturnNull(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')
-            ->get();
+        $mock = $builder->stub('myMethod')->get();
         $this->assert($mock->myMethod(), is_null);
     }
 
@@ -73,8 +73,7 @@ class BuilderStubTest extends AbstractBuilderTestCase
      */
     public function testStubCanReturnNull(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andReturn(null)
-            ->get();
+        $mock = $builder->stub('myMethod')->andReturn(null)->get();
         $this->assert($mock->myMethod(), is_null);
     }
 
@@ -85,7 +84,8 @@ class BuilderStubTest extends AbstractBuilderTestCase
      */
     public function testStubCanThrowException(MockBuilder $builder)
     {
-        $mock = $builder->stub('myMethod')->andThrow(new \Exception('whatever'))
+        $mock = $builder->stub('myMethod')
+            ->andThrow(new \Exception('whatever'))
             ->get();
         $mock->myMethod();
     }
@@ -95,10 +95,10 @@ class BuilderStubTest extends AbstractBuilderTestCase
      * @expectedExceptionMessage myMethod() has more than one action attached.
      * @dataProvider allBuilders
      */
-    public function testMethodsCanOnlyHaveOneActionAppliedToThem(MockBuilder $builder)
-    {
-        $builder->stub('myMethod')->andReturn(123)->andReturn(456)
-            ->get();
+    public function testMethodsCanOnlyHaveOneActionAppliedToThem(
+        MockBuilder $builder
+    ) {
+        $builder->stub('myMethod')->andReturn(123)->andReturn(456)->get();
     }
 
     protected function getLastElement(array $a)
@@ -109,71 +109,87 @@ class BuilderStubTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMockSetsActualCallsToZeroWhenRuleIsCreated(MockBuilder $builder)
-    {
-        $builder->stub(array('myMethod' => 123))
-            ->get();
+    public function testMockSetsActualCallsToZeroWhenRuleIsCreated(
+        MockBuilder $builder
+    ) {
+        $builder->stub(array('myMethod' => 123))->get();
 
         $mock = $this->getLastElement($this->getMockManager()->getMocks());
-        $this->assert(count($mock['instance']->getCallsForMethod('myMethod')), exactly_equals, 0);
+        $this->assert(
+            count($mock['instance']->getCallsForMethod('myMethod')),
+            exactly_equals,
+            0
+        );
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testMockSetsCalledTimesToOneWhenMethodIsCalled(MockBuilder $builder)
-    {
-        $mock = $builder->stub(array('myMethod' => 123))
-            ->get();
+    public function testMockSetsCalledTimesToOneWhenMethodIsCalled(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub(array('myMethod' => 123))->get();
 
         $mock->myMethod();
 
         $mock = $this->getLastElement($this->getMockManager()->getMocks());
-        $this->assert(count($mock['instance']->getCallsForMethod('myMethod')), exactly_equals, 1);
+        $this->assert(
+            count($mock['instance']->getCallsForMethod('myMethod')),
+            exactly_equals,
+            1
+        );
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testMockSetsCalledTimesIncrementsWithMultipleCalls(MockBuilder $builder)
-    {
-        $mock = $builder->stub(array('myMethod' => 123))
-            ->get();
+    public function testMockSetsCalledTimesIncrementsWithMultipleCalls(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub(array('myMethod' => 123))->get();
 
         $mock->myMethod();
         $mock->myMethod();
 
         $mock = $this->getLastElement($this->getMockManager()->getMocks());
-        $this->assert(count($mock['instance']->getCallsForMethod('myMethod')), exactly_equals, 2);
+        $this->assert(
+            count($mock['instance']->getCallsForMethod('myMethod')),
+            exactly_equals,
+            2
+        );
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testStubbingMultipleMethodsWithMultipleArguments(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod', 'mySecondMethod')
-            ->get();
+    public function testStubbingMultipleMethodsWithMultipleArguments(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myMethod', 'mySecondMethod')->get();
         $this->assert($mock->mySecondMethod(), is_null);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testFirstMethodOfMultipleStubsReceivesAction(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')
-            ->get();
+    public function testFirstMethodOfMultipleStubsReceivesAction(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get(
+                );
         $this->assert($mock->myMethod(), equals, 'foo');
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testSecondMethodOfMultipleStubsReceivesAction(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')
-            ->get();
+    public function testSecondMethodOfMultipleStubsReceivesAction(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get(
+                );
         $this->assert($mock->mySecondMethod(), equals, 'foo');
     }
 }

--- a/tests/Concise/Mock/BuilderStubTest.php
+++ b/tests/Concise/Mock/BuilderStubTest.php
@@ -176,8 +176,7 @@ class BuilderStubTest extends AbstractBuilderTestCase
         MockBuilder $builder
     ) {
         $mock =
-            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get(
-                );
+            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get();
         $this->assert($mock->myMethod(), equals, 'foo');
     }
 
@@ -188,8 +187,7 @@ class BuilderStubTest extends AbstractBuilderTestCase
         MockBuilder $builder
     ) {
         $mock =
-            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get(
-                );
+            $builder->stub('myMethod', 'mySecondMethod')->andReturn('foo')->get();
         $this->assert($mock->mySecondMethod(), equals, 'foo');
     }
 }

--- a/tests/Concise/Mock/BuilderWithTest.php
+++ b/tests/Concise/Mock/BuilderWithTest.php
@@ -10,33 +10,39 @@ class BuilderWithTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testMultipleWithIsAllowedForASingleMethod(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myWithMethod')->with('a')->andReturn('foo')
-            ->with('b')->andReturn('bar')
-            ->get();
+    public function testMultipleWithIsAllowedForASingleMethod(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
+                    'b'
+                )->andReturn('bar')->get();
         $this->assert($mock, instance_of, $builder->getClassName());
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testMultipleWithCanChangeTheActionOfTheMethod(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myWithMethod')->with('a')->andReturn('foo')
-            ->with('b')->andReturn('bar')
-            ->get();
+    public function testMultipleWithCanChangeTheActionOfTheMethod(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
+                    'b'
+                )->andReturn('bar')->get();
         $this->assert($mock->myWithMethod('b'), equals, 'bar');
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testTheSecondWithActionWillNotOverrideTheFirstOne(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myWithMethod')->with('a')->andReturn('foo')
-            ->with('b')->andReturn('bar')
-            ->get();
+    public function testTheSecondWithActionWillNotOverrideTheFirstOne(
+        MockBuilder $builder
+    ) {
+        $mock =
+            $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
+                    'b'
+                )->andReturn('bar')->get();
         $this->assert($mock->myWithMethod('a'), equals, 'foo');
     }
 
@@ -45,7 +51,10 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testSingleWithWithMultipleTimes(MockBuilder $builder)
     {
-        $mock = $builder->stub('myWithMethod')->with('a')->twice()->andReturn('foo')
+        $mock = $builder->stub('myWithMethod')
+            ->with('a')
+            ->twice()
+            ->andReturn('foo')
             ->get();
         $mock->myWithMethod('a');
         $this->assert($mock->myWithMethod('a'), equals, 'foo');
@@ -54,20 +63,20 @@ class BuilderWithTest extends AbstractBuilderTestCase
     /**
      * @dataProvider allBuilders
      */
-    public function testStringsInExpectedArgumentsMustBeEscapedCorrectly(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myWithMethod')->with('"foo"')
-            ->get();
+    public function testStringsInExpectedArgumentsMustBeEscapedCorrectly(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myWithMethod')->with('"foo"')->get();
         $this->assert($mock->myWithMethod('"foo"'), is_null);
     }
 
     /**
      * @dataProvider allBuilders
      */
-    public function testStringsWithDollarCharacterMustBeEscaped(MockBuilder $builder)
-    {
-        $mock = $builder->stub('myWithMethod')->with('a$b')
-            ->get();
+    public function testStringsWithDollarCharacterMustBeEscaped(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->stub('myWithMethod')->with('a$b')->get();
         $this->assert($mock->myWithMethod('a$b'), is_null);
     }
 
@@ -76,8 +85,10 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testWithOnMultipleMethods(MockBuilder $builder)
     {
-        $mock = $builder->stub('myWithMethod', 'myMethod')->with('foo')->andReturn('foobar')
-            ->get();
+        $mock =
+            $builder->stub('myWithMethod', 'myMethod')->with('foo')->andReturn(
+                'foobar'
+            )->get();
         $this->assert($mock->myMethod('foo'), equals, 'foobar');
     }
 
@@ -86,8 +97,10 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testMultipleExpectsUsingTheSameWith(MockBuilder $builder)
     {
-        $mock = $builder->expect('myWithMethod')->with('foo')
-            ->expect('myMethod')->with('foo')
+        $mock = $builder->expect('myWithMethod')
+            ->with('foo')
+            ->expect('myMethod')
+            ->with('foo')
             ->get();
         $mock->myWithMethod('foo');
         $mock->myMethod('foo');
@@ -98,8 +111,8 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testMultipleExpectsUsingWith(MockBuilder $builder)
     {
-        $mock = $builder->expect('myWithMethod', 'myMethod')->with('foo')
-            ->get();
+        $mock =
+            $builder->expect('myWithMethod', 'myMethod')->with('foo')->get();
         $mock->myWithMethod('foo');
         $mock->myMethod('foo');
     }
@@ -110,8 +123,10 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testMultipleWithsNotBeingFulfilled(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod')->with('foo')
-            ->with('bar')->never()
+        $mock = $builder->expect('myMethod')
+            ->with('foo')
+            ->with('bar')
+            ->never()
             ->get();
 
         $mock->myMethod('foo');
@@ -121,9 +136,12 @@ class BuilderWithTest extends AbstractBuilderTestCase
      * @group #225
      * @dataProvider allBuilders
      */
-    public function testMultipleWithsNotBeingFulfilledInDifferentOrder(MockBuilder $builder)
-    {
-        $mock = $builder->expect('myMethod')->with('bar')->never()
+    public function testMultipleWithsNotBeingFulfilledInDifferentOrder(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->expect('myMethod')
+            ->with('bar')
+            ->never()
             ->with('foo')
             ->get();
 
@@ -136,7 +154,10 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testWithUsingDefaultArguments(MockBuilder $builder)
     {
-        $mock = $builder->expect('myWithMethodDefaults')->with('foo', 'bar')->andReturn(null)->get();
+        $mock = $builder->expect('myWithMethodDefaults')
+            ->with('foo', 'bar')
+            ->andReturn(null)
+            ->get();
         $mock->myWithMethodDefaults('foo', 'bar');
     }
 
@@ -144,9 +165,13 @@ class BuilderWithTest extends AbstractBuilderTestCase
      * @group #168
      * @dataProvider allBuilders
      */
-    public function testWithUsingSingleDefaultArgumentNotProvided(MockBuilder $builder)
-    {
-        $mock = $builder->expect('myWithMethodDefaults')->with('bar', 'foo', 'baz')->andReturn(null)->get();
+    public function testWithUsingSingleDefaultArgumentNotProvided(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->expect('myWithMethodDefaults')
+            ->with('bar', 'foo', 'baz')
+            ->andReturn(null)
+            ->get();
         $mock->myWithMethodDefaults('bar', 'foo');
     }
 
@@ -154,9 +179,13 @@ class BuilderWithTest extends AbstractBuilderTestCase
      * @group #168
      * @dataProvider allBuilders
      */
-    public function testWithUsingMultipleDefaultArgumentNotProvided(MockBuilder $builder)
-    {
-        $mock = $builder->expect('myWithMethodDefaults')->with('bar', 'foo', 'baz')->andReturn(null)->get();
+    public function testWithUsingMultipleDefaultArgumentNotProvided(
+        MockBuilder $builder
+    ) {
+        $mock = $builder->expect('myWithMethodDefaults')
+            ->with('bar', 'foo', 'baz')
+            ->andReturn(null)
+            ->get();
         $mock->myWithMethodDefaults('bar');
     }
 
@@ -166,8 +195,7 @@ class BuilderWithTest extends AbstractBuilderTestCase
      */
     public function testWithIncludingSingleQuotes(MockBuilder $builder)
     {
-        $mock = $builder->expect('myMethod')->with("foo'bar")
-            ->get();
+        $mock = $builder->expect('myMethod')->with("foo'bar")->get();
 
         $mock->myMethod("foo'bar");
     }

--- a/tests/Concise/Mock/BuilderWithTest.php
+++ b/tests/Concise/Mock/BuilderWithTest.php
@@ -15,8 +15,8 @@ class BuilderWithTest extends AbstractBuilderTestCase
     ) {
         $mock =
             $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
-                    'b'
-                )->andReturn('bar')->get();
+                'b'
+            )->andReturn('bar')->get();
         $this->assert($mock, instance_of, $builder->getClassName());
     }
 
@@ -28,8 +28,8 @@ class BuilderWithTest extends AbstractBuilderTestCase
     ) {
         $mock =
             $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
-                    'b'
-                )->andReturn('bar')->get();
+                'b'
+            )->andReturn('bar')->get();
         $this->assert($mock->myWithMethod('b'), equals, 'bar');
     }
 
@@ -41,8 +41,8 @@ class BuilderWithTest extends AbstractBuilderTestCase
     ) {
         $mock =
             $builder->stub('myWithMethod')->with('a')->andReturn('foo')->with(
-                    'b'
-                )->andReturn('bar')->get();
+                'b'
+            )->andReturn('bar')->get();
         $this->assert($mock->myWithMethod('a'), equals, 'foo');
     }
 

--- a/tests/Concise/Mock/ClassCompilerExposeTest.php
+++ b/tests/Concise/Mock/ClassCompilerExposeTest.php
@@ -2,8 +2,8 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
-use \Concise\Mock\Action\ReturnValueAction;
+use Concise\Mock\Action\ReturnValueAction;
+use Concise\TestCase;
 use ReflectionClass;
 
 class ClassCompilerMock3
@@ -33,7 +33,8 @@ class ClassCompilerExposeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->compiler = new ClassCompiler('\Concise\Mock\ClassCompilerMock3', true);
+        $this->compiler =
+            new ClassCompiler('\Concise\Mock\ClassCompilerMock3', true);
     }
 
     public function testAMethodCanBeExposed()
@@ -45,14 +46,16 @@ class ClassCompilerExposeTest extends TestCase
 
     protected function setRulesForExposure()
     {
-        $this->compiler->setRules(array(
-            'hidden' => array(
-                array(
-                    'action' => new ReturnValueAction(array('bar')),
-                    'with'   => null,
+        $this->compiler->setRules(
+            array(
+                'hidden' => array(
+                    array(
+                        'action' => new ReturnValueAction(array('bar')),
+                        'with' => null,
+                    ),
                 ),
-            ),
-        ));
+            )
+        );
     }
 
     public function testAMethodThatHasARuleCanBeExposed()
@@ -67,7 +70,10 @@ class ClassCompilerExposeTest extends TestCase
     {
         $instance = $this->compiler->newInstance();
         $reflectionClass = new ReflectionClass(get_class($instance));
-        $this->assert($reflectionClass->getMethod('hidden')->isPublic(), is_false);
+        $this->assert(
+            $reflectionClass->getMethod('hidden')->isPublic(),
+            is_false
+        );
     }
 
     public function testExposingOneMethodWillNotExposeThemAll()
@@ -75,7 +81,10 @@ class ClassCompilerExposeTest extends TestCase
         $this->compiler->addExpose('hidden');
         $instance = $this->compiler->newInstance();
         $reflectionClass = new ReflectionClass(get_class($instance));
-        $this->assert($reflectionClass->getMethod('hidden2')->isPublic(), is_false);
+        $this->assert(
+            $reflectionClass->getMethod('hidden2')->isPublic(),
+            is_false
+        );
     }
 
     public function testAddingARuleToAMethodWillNotExposeThemAll()
@@ -83,7 +92,10 @@ class ClassCompilerExposeTest extends TestCase
         $this->setRulesForExposure();
         $instance = $this->compiler->newInstance();
         $reflectionClass = new ReflectionClass(get_class($instance));
-        $this->assert($reflectionClass->getMethod('hidden2')->isPublic(), is_false);
+        $this->assert(
+            $reflectionClass->getMethod('hidden2')->isPublic(),
+            is_false
+        );
     }
 
     public function testAddingARuleToAMethodWillNotExposeIt()
@@ -91,7 +103,10 @@ class ClassCompilerExposeTest extends TestCase
         $this->setRulesForExposure();
         $instance = $this->compiler->newInstance();
         $reflectionClass = new ReflectionClass(get_class($instance));
-        $this->assert($reflectionClass->getMethod('hidden')->isPublic(), is_false);
+        $this->assert(
+            $reflectionClass->getMethod('hidden')->isPublic(),
+            is_false
+        );
     }
 
     public function testMocksThatAreNotNiceWillNotExposeAMethod()
@@ -99,7 +114,10 @@ class ClassCompilerExposeTest extends TestCase
         $this->compiler = new ClassCompiler('\Concise\Mock\ClassCompilerMock3');
         $instance = $this->compiler->newInstance();
         $reflectionClass = new ReflectionClass(get_class($instance));
-        $this->assert($reflectionClass->getMethod('hidden')->isPublic(), is_false);
+        $this->assert(
+            $reflectionClass->getMethod('hidden')->isPublic(),
+            is_false
+        );
     }
 
     public function testTwoMethodsCanBeExposed()
@@ -118,18 +136,21 @@ class ClassCompilerExposeTest extends TestCase
     }
 
     /**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage Method Concise\Mock\ClassCompilerMock3::foo() does not exist.
-	 */
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Method Concise\Mock\ClassCompilerMock3::foo()
+     *     does not exist.
+     */
     public function testAnExceptionIsThrownIfTheMethodDoesNotExist()
     {
         $this->compiler->addExpose('foo');
     }
 
     /**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage Method Concise\Mock\ClassCompilerMock3::superSecret() cannot be mocked because it it private.
-	 */
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Method
+     *     Concise\Mock\ClassCompilerMock3::superSecret() cannot be mocked
+     *     because it it private.
+     */
     public function testTryingToExposeAPrivateMethodThrowsException()
     {
         $this->compiler->addExpose('superSecret');

--- a/tests/Concise/Mock/ClassCompilerInterfaceTest.php
+++ b/tests/Concise/Mock/ClassCompilerInterfaceTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 interface ClassCompilerMock4
 {
@@ -19,6 +19,10 @@ class ClassCompilerInterfaceTest extends TestCase
     public function testWillImplementAnInterface()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock4');
-        $this->assert($compiler->newInstance(), instance_of, 'Concise\Mock\ClassCompilerMock4');
+        $this->assert(
+            $compiler->newInstance(),
+            instance_of,
+            'Concise\Mock\ClassCompilerMock4'
+        );
     }
 }

--- a/tests/Concise/Mock/ClassCompilerTest.php
+++ b/tests/Concise/Mock/ClassCompilerTest.php
@@ -87,8 +87,7 @@ class ClassCompilerTest extends TestCase
         $compiler->newInstance();
     }
 
-    public function testExtraBackslashesAtTheStartOfTheClassNameWillBeTrimmedOff(
-    )
+    public function testExtraBackslashesAtTheStartOfTheClassNameWillBeTrimmedOff()
     {
         $compiler = new ClassCompiler('\Concise\Mock\ClassCompilerMock2');
         $this->assert(

--- a/tests/Concise/Mock/ClassCompilerTest.php
+++ b/tests/Concise/Mock/ClassCompilerTest.php
@@ -18,13 +18,17 @@ class ClassCompilerTest extends TestCase
     public function testClassNameIsUsedInTheNamingOfTheMockClass()
     {
         $compiler = new ClassCompiler('DateTime');
-        $this->assertPHP($compiler, "class DateTime_% extends \\DateTime implements % {%}");
+        $this->assertPHP(
+            $compiler,
+            "class DateTime_% extends \\DateTime implements % {%}"
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage The class 'DoesntExist' is not loaded so it cannot be mocked.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage The class 'DoesntExist' is not loaded so it
+     *     cannot be mocked.
+     */
     public function testExceptionIsThrownIfClassToBeMockedIsNotLoaded()
     {
         new ClassCompiler('DoesntExist');
@@ -33,74 +37,115 @@ class ClassCompilerTest extends TestCase
     public function testMockedClassesWillBePutIntoTheCorrectNamespace()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
-        $this->assertPHP($compiler, "namespace Concise\Mock; class ClassCompilerMock1_% extends \Concise\Mock\ClassCompilerMock1 implements % {%}");
+        $this->assertPHP(
+            $compiler,
+            "namespace Concise\Mock; class ClassCompilerMock1_% extends \Concise\Mock\ClassCompilerMock1 implements % {%}"
+        );
     }
 
     public function testInstanceCanBeReturnedFromGeneratedCode()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
-        $this->assert($compiler->newInstance(), instance_of, 'Concise\Mock\ClassCompilerMock1');
+        $this->assert(
+            $compiler->newInstance(),
+            instance_of,
+            'Concise\Mock\ClassCompilerMock1'
+        );
     }
 
     public function testCanGenerateMockFromAbstractClass()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock2');
-        $this->assert($compiler->newInstance(), instance_of, 'Concise\Mock\ClassCompilerMock2');
+        $this->assert(
+            $compiler->newInstance(),
+            instance_of,
+            'Concise\Mock\ClassCompilerMock2'
+        );
     }
 
     public function testMultipleMocksGeneratedFromTheSameClassIsPossible()
     {
         $a = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
         $b = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
-        $this->assert($a->newInstance(), is_not_exactly_equal_to, $b->newInstance());
+        $this->assert(
+            $a->newInstance(),
+            is_not_exactly_equal_to,
+            $b->newInstance()
+        );
     }
 
     /**
-	 * @param string $php
-	 */
+     * @param string $php
+     */
     protected function assertPHP(ClassCompiler $compiler, $php)
     {
-        $this->assert($compiler->generateCode(), matches_regex, '/' . str_replace('%', '(.*)', preg_quote($php)) . '/sm');
+        $this->assert(
+            $compiler->generateCode(),
+            matches_regex,
+            '/' . str_replace('%', '(.*)', preg_quote($php)) . '/sm'
+        );
         $compiler->newInstance();
     }
 
-    public function testExtraBackslashesAtTheStartOfTheClassNameWillBeTrimmedOff()
+    public function testExtraBackslashesAtTheStartOfTheClassNameWillBeTrimmedOff(
+    )
     {
         $compiler = new ClassCompiler('\Concise\Mock\ClassCompilerMock2');
-        $this->assert($compiler->newInstance(), instance_of, 'Concise\Mock\ClassCompilerMock2');
+        $this->assert(
+            $compiler->newInstance(),
+            instance_of,
+            'Concise\Mock\ClassCompilerMock2'
+        );
     }
 
     public function testTheNameOfTheClassCanBeSet()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
         $compiler->setCustomClassName('MyCustomClass');
-        $this->assert(get_class($compiler->newInstance()), equals, 'Concise\Mock\MyCustomClass');
+        $this->assert(
+            get_class($compiler->newInstance()),
+            equals,
+            'Concise\Mock\MyCustomClass'
+        );
     }
 
     public function testTheClassCanBeCreatedInADifferentNamespace()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
         $compiler->setCustomClassName('Other\Place\MyRandomClass');
-        $this->assert(get_class($compiler->newInstance()), equals, 'Other\Place\MyRandomClass');
+        $this->assert(
+            get_class($compiler->newInstance()),
+            equals,
+            'Other\Place\MyRandomClass'
+        );
     }
 
     public function testTheClassCanBeMovedIntoTheGlobalNamespace()
     {
         $compiler = new ClassCompiler('Concise\Mock\ClassCompilerMock1');
         $compiler->setCustomClassName('\MyCustomClass');
-        $this->assert(get_class($compiler->newInstance()), equals, 'MyCustomClass');
+        $this->assert(
+            get_class($compiler->newInstance()),
+            equals,
+            'MyCustomClass'
+        );
     }
 
     public function testWillIgnorePreceedingBackslashForCustomClassName()
     {
         $compiler = new ClassCompiler('\Concise\Mock\ClassCompilerMock2');
         $compiler->setCustomClassName('\Concise\Mock\ClassCompilerMock2Foo');
-        $this->assert($compiler->newInstance(), instance_of, 'Concise\Mock\ClassCompilerMock2');
+        $this->assert(
+            $compiler->newInstance(),
+            instance_of,
+            'Concise\Mock\ClassCompilerMock2'
+        );
     }
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot use 'DateTime' because a class with that name already exists.
+     * @expectedExceptionMessage You cannot use 'DateTime' because a class with
+     *     that name already exists.
      */
     public function testCustomClassNameCannotBeUsedIfTheClassAlreadyExists()
     {
@@ -128,11 +173,14 @@ class ClassCompilerTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected boolean, but got integer for argument 4
+     * @expectedExceptionMessage Expected boolean, but got integer for argument
+     *     4
      */
     public function testDisableConstructorMustBeABoolean()
     {
-        new ClassCompiler('Concise\Mock\ClassCompilerMock1', false, array(), 123);
+        new ClassCompiler(
+            'Concise\Mock\ClassCompilerMock1', false, array(), 123
+        );
     }
 
     /**

--- a/tests/Concise/Mock/InvocationTest.php
+++ b/tests/Concise/Mock/InvocationTest.php
@@ -24,7 +24,11 @@ class InvocationTest extends TestCase
     public function testImplementsInvocationInterface()
     {
         $invocation = new Invocation();
-        $this->assert($invocation, instance_of, '\Concise\Mock\InvocationInterface');
+        $this->assert(
+            $invocation,
+            instance_of,
+            '\Concise\Mock\InvocationInterface'
+        );
     }
 
     public function testConstructorCanInitialiseInvokeCount()

--- a/tests/Concise/Mock/MockBuilderConstructorTest.php
+++ b/tests/Concise/Mock/MockBuilderConstructorTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class MockConstructor1
 {
@@ -35,24 +35,23 @@ class MockBuilderConstructorTest extends TestCase
 {
     public function testMocksWillCallConstructorByDefault()
     {
-        $mock = $this->mock('\Concise\Mock\MockConstructor1')
-                     ->get();
+        $mock = $this->mock('\Concise\Mock\MockConstructor1')->get();
         $this->assert($mock->constructorRun);
     }
 
     public function testDisableConstructorCanBeChained()
     {
         $mock = $this->mock('\Concise\Mock\MockConstructor1')
-                     ->disableConstructor()
-                     ->get();
+            ->disableConstructor()
+            ->get();
         $this->assert($mock, instance_of, '\Concise\Mock\MockConstructor1');
     }
 
     public function testMocksCanHaveTheirConstructorDisabledWithArguments()
     {
         $mock = $this->mock('\Concise\Mock\MockConstructor2')
-                     ->disableConstructor()
-                     ->get();
+            ->disableConstructor()
+            ->get();
         $this->assert($mock, instance_of, '\Concise\Mock\MockConstructor2');
     }
 }

--- a/tests/Concise/Mock/MockBuilderExpectTest.php
+++ b/tests/Concise/Mock/MockBuilderExpectTest.php
@@ -23,8 +23,7 @@ class MockBuilderExpectTest extends TestCase
      *     for each with():
      * @expectedExceptionMessage ->expects('myMethod')->with("foo")->twice()
      */
-    public function testAnExceptionShouldCorrectExplainUsingWithAndExpectationTimes(
-    )
+    public function testAnExceptionShouldCorrectExplainUsingWithAndExpectationTimes()
     {
         $this->mock()->expects('myMethod')->twice()->with("foo");
     }

--- a/tests/Concise/Mock/MockBuilderExpectTest.php
+++ b/tests/Concise/Mock/MockBuilderExpectTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 /**
  * @group mocking
@@ -14,18 +14,18 @@ class MockBuilderExpectTest extends TestCase
      */
     public function testUsingExpectationCountBeforeWithWillThrowException()
     {
-        $this->mock()
-             ->expects('myMethod')->once()->with('foo');
+        $this->mock()->expects('myMethod')->once()->with('foo');
     }
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage When using with you must specify expectations for each with():
+     * @expectedExceptionMessage When using with you must specify expectations
+     *     for each with():
      * @expectedExceptionMessage ->expects('myMethod')->with("foo")->twice()
      */
-    public function testAnExceptionShouldCorrectExplainUsingWithAndExpectationTimes()
+    public function testAnExceptionShouldCorrectExplainUsingWithAndExpectationTimes(
+    )
     {
-        $this->mock()
-             ->expects('myMethod')->twice()->with("foo");
+        $this->mock()->expects('myMethod')->twice()->with("foo");
     }
 }

--- a/tests/Concise/Mock/MockBuilderExposeTest.php
+++ b/tests/Concise/Mock/MockBuilderExposeTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class MockExpose
 {
@@ -29,13 +29,12 @@ class MockBuilderExposeTest extends TestCase
     }
 
     /**
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessage Method Concise\Mock\MockExpose::baz() does not exist.
-	 */
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Method Concise\Mock\MockExpose::baz() does not
+     *     exist.
+     */
     public function testAnExceptionIsThrownIfTheMethodDoesNotExist()
     {
-        $this->niceMock('\Concise\Mock\MockExpose')
-             ->expose('baz')
-             ->get();
+        $this->niceMock('\Concise\Mock\MockExpose')->expose('baz')->get();
     }
 }

--- a/tests/Concise/Mock/MockBuilderFailuresTest.php
+++ b/tests/Concise/Mock/MockBuilderFailuresTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 /**
  * @group mocking
@@ -31,72 +31,86 @@ class MockBuilderFailuresTest extends TestCase
 
     public function testFailedToFulfilExpectationWillThrowException()
     {
-        $this->mock('\Concise\Mock\Mock1')
-             ->expect('myMethod')
-             ->get();
+        $this->mock('\Concise\Mock\Mock1')->expect('myMethod')->get();
     }
 
     public function testMethodCalledWithWrongArgumentValues()
     {
         $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo')
-                           ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->get();
         $this->mock->myMethod('bar');
     }
 
     public function testMissingSecondWithExpectation()
     {
         $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo')->with('bar')
-                           ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->with('bar')
+            ->get();
         $this->mock->myMethod('bar');
     }
 
     public function testExpectationsRenderMultipleArguments()
     {
-        $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo', 'bar')
-                           ->get();
+        $this->mock =
+            $this->mock('\Concise\Mock\Mock1')->expect('myMethod')->with(
+                    'foo',
+                    'bar'
+                )->get();
         $this->mock->myMethod('bar');
     }
 
     public function testMissingAllExpectations()
     {
         $this->mock('\Concise\Mock\Mock1')
-             ->expect('myMethod')->with('foo')->with('bar')
-             ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->with('bar')
+            ->get();
     }
 
     public function testLessTimesThanExpected()
     {
         $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo')->twice()
-                                               ->with('bar')
-                           ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->twice()
+            ->with('bar')
+            ->get();
         $this->mock->myMethod('foo');
     }
 
     public function testExpectionThatIsNeverCalledWillFail()
     {
         $this->mock('\Concise\Mock\Mock1')
-             ->expect('myMethod')->with('foo')->andReturn('bar')
-             ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->andReturn('bar')
+            ->get();
     }
 
     public function testExpectionMustBeCalledTheRequiredAmountOfTimes()
     {
         $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo')->twice()->andReturn('bar')
-                           ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->twice()
+            ->andReturn('bar')
+            ->get();
         $this->mock->myMethod('foo');
     }
 
     public function testMoreTimesThanExpected()
     {
         $this->mock = $this->mock('\Concise\Mock\Mock1')
-                           ->expect('myMethod')->with('foo')->twice()
-                                               ->with('bar')
-                           ->get();
+            ->expect('myMethod')
+            ->with('foo')
+            ->twice()
+            ->with('bar')
+            ->get();
         $this->mock->myMethod('foo');
         $this->mock->myMethod('foo');
         $this->mock->myMethod('foo');
@@ -105,37 +119,39 @@ class MockBuilderFailuresTest extends TestCase
     public function testWithArgumentsMayContainPercentageThatWasntCalled()
     {
         $mock = $this->mock('\Concise\Mock\Mock1')
-                     ->expects('myMethod')->with('%d')
-                     ->get();
+            ->expects('myMethod')
+            ->with('%d')
+            ->get();
     }
 
     public function testWithArgumentsWillNotMistakeAnArrayForACallback()
     {
-        $mock = $this->mock('\Concise\Mock\Mock1')
-                     ->expects('myMethod')->with(array('DateTime', 'getLastErrors'))
-                     ->get();
+        $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
+                array('DateTime', 'getLastErrors')
+            )->get();
     }
 
     public function testWithArgumentsUsingDifferentCallback()
     {
-        $mock = $this->mock('\Concise\Mock\Mock1')
-                     ->expects('myMethod')->with(array('DateTime', '__set_state'))
-                     ->get();
+        $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
+                array('DateTime', '__set_state')
+            )->get();
         $mock->myMethod(array('DateTime', 'getLastErrors'));
     }
 
-    public function testAbstractMethodOnANiceMockThatHasNoActionWillThrowException()
+    public function testAbstractMethodOnANiceMockThatHasNoActionWillThrowException(
+    )
     {
-        $mock = $this->niceMock('\Concise\Mock\AbstractMock1')
-                     ->get();
+        $mock = $this->niceMock('\Concise\Mock\AbstractMock1')->get();
         $mock->myMethod();
     }
 
     public function testAnythingIsRenderedCorrectly()
     {
-        $mock = $this->mock('\Concise\Mock\Mock1')
-                     ->expects('myMethod')->with(self::ANYTHING, 'foo')
-                     ->get();
+        $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
+                self::ANYTHING,
+                'foo'
+            )->get();
     }
 
     /**
@@ -144,8 +160,9 @@ class MockBuilderFailuresTest extends TestCase
     public function testWithFailureWithDifferentArgs()
     {
         $mock = $this->mock('\Concise\Mock\Mock1')
-                     ->expects('myMethod')->with('foo')
-                     ->get();
+            ->expects('myMethod')
+            ->with('foo')
+            ->get();
 
         $mock->myMethod('bar');
     }
@@ -153,7 +170,11 @@ class MockBuilderFailuresTest extends TestCase
     protected function onNotSuccessfulTest(\Exception $e)
     {
         self::$failures[] = $this->getName();
-        $this->assert(self::$expectedFailures[$this->getName()], equals, $e->getMessage());
+        $this->assert(
+            self::$expectedFailures[$this->getName()],
+            equals,
+            $e->getMessage()
+        );
     }
 
     public static function tearDownAfterClass()

--- a/tests/Concise/Mock/MockBuilderFailuresTest.php
+++ b/tests/Concise/Mock/MockBuilderFailuresTest.php
@@ -57,9 +57,9 @@ class MockBuilderFailuresTest extends TestCase
     {
         $this->mock =
             $this->mock('\Concise\Mock\Mock1')->expect('myMethod')->with(
-                    'foo',
-                    'bar'
-                )->get();
+                'foo',
+                'bar'
+            )->get();
         $this->mock->myMethod('bar');
     }
 
@@ -127,20 +127,19 @@ class MockBuilderFailuresTest extends TestCase
     public function testWithArgumentsWillNotMistakeAnArrayForACallback()
     {
         $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
-                array('DateTime', 'getLastErrors')
-            )->get();
+            array('DateTime', 'getLastErrors')
+        )->get();
     }
 
     public function testWithArgumentsUsingDifferentCallback()
     {
         $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
-                array('DateTime', '__set_state')
-            )->get();
+            array('DateTime', '__set_state')
+        )->get();
         $mock->myMethod(array('DateTime', 'getLastErrors'));
     }
 
-    public function testAbstractMethodOnANiceMockThatHasNoActionWillThrowException(
-    )
+    public function testAbstractMethodOnANiceMockThatHasNoActionWillThrowException()
     {
         $mock = $this->niceMock('\Concise\Mock\AbstractMock1')->get();
         $mock->myMethod();
@@ -149,9 +148,9 @@ class MockBuilderFailuresTest extends TestCase
     public function testAnythingIsRenderedCorrectly()
     {
         $mock = $this->mock('\Concise\Mock\Mock1')->expects('myMethod')->with(
-                self::ANYTHING,
-                'foo'
-            )->get();
+            self::ANYTHING,
+            'foo'
+        )->get();
     }
 
     /**

--- a/tests/Concise/Mock/MockBuilderTest.php
+++ b/tests/Concise/Mock/MockBuilderTest.php
@@ -31,14 +31,12 @@ class MockBuilderTest extends TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage Class or interface '\Abc' does not exist.
      */
-    public function testExceptionIsThrownIfTheClassTryingToBeMockedDoesNotExist(
-    )
+    public function testExceptionIsThrownIfTheClassTryingToBeMockedDoesNotExist()
     {
         $this->mock('\Abc')->get();
     }
 
-    public function testMockingAMethodThatDoesNotExistIfThereIsAMagicCallMethod(
-    )
+    public function testMockingAMethodThatDoesNotExistIfThereIsAMagicCallMethod()
     {
         $mock =
             $this->mock('\Concise\Mock\MockMagicCall')->stub('nothing')->get();

--- a/tests/Concise/Mock/MockBuilderTest.php
+++ b/tests/Concise/Mock/MockBuilderTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 abstract class Mock2
 {
@@ -28,33 +28,32 @@ class MockMagicCall
 class MockBuilderTest extends TestCase
 {
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Class or interface '\Abc' does not exist.
-	 */
-    public function testExceptionIsThrownIfTheClassTryingToBeMockedDoesNotExist()
+     * @expectedException \Exception
+     * @expectedExceptionMessage Class or interface '\Abc' does not exist.
+     */
+    public function testExceptionIsThrownIfTheClassTryingToBeMockedDoesNotExist(
+    )
     {
         $this->mock('\Abc')->get();
     }
 
-    public function testMockingAMethodThatDoesNotExistIfThereIsAMagicCallMethod()
+    public function testMockingAMethodThatDoesNotExistIfThereIsAMagicCallMethod(
+    )
     {
-        $mock = $this->mock('\Concise\Mock\MockMagicCall')
-                     ->stub('nothing')
-                     ->get();
+        $mock =
+            $this->mock('\Concise\Mock\MockMagicCall')->stub('nothing')->get();
         $this->assert($mock->nothing(), is_null);
     }
 
     public function testMockClassDefaultsToStdClass()
     {
-        $mock = $this->mock()
-                     ->get();
+        $mock = $this->mock()->get();
         $this->assert($mock, instance_of, '\stdClass');
     }
 
     public function testNiceMockClassDefaultsToStdClass()
     {
-        $mock = $this->niceMock()
-                     ->get();
+        $mock = $this->niceMock()->get();
         $this->assert($mock, instance_of, '\stdClass');
     }
 

--- a/tests/Concise/Mock/MockVerifyTest.php
+++ b/tests/Concise/Mock/MockVerifyTest.php
@@ -6,9 +6,9 @@ use Concise\TestCase;
 
 class DummyMock implements MockInterface
 {
-	public function getCallsForMethod($method)
-	{
-	}
+    public function getCallsForMethod($method)
+    {
+    }
 }
 
 /**
@@ -17,73 +17,79 @@ class DummyMock implements MockInterface
  */
 class MockVerifyTest extends TestCase
 {
-	public function testManuallyVerifyingAMockWillReturnTrue()
-	{
-		$mock = $this->mock()->get();
-		$this->assert($this->assertMock($mock), is_true);
-	}
+    public function testManuallyVerifyingAMockWillReturnTrue()
+    {
+        $mock = $this->mock()->get();
+        $this->assert($this->assertMock($mock), is_true);
+    }
 
-	public function testWillThrowExceptionIfMockDoesNotSatifyRequirements()
-	{
-		$mock = $this->mock('\DateTime')
-			->expect('getLastErrors')
-			->get();
-		$self = $this;
-		$this->assert(function () use ($mock, $self) {
-			$self->assertMock($mock);
-		}, throws, '\PHPUnit_Framework_AssertionFailedError');
-	}
+    public function testWillThrowExceptionIfMockDoesNotSatifyRequirements()
+    {
+        $mock = $this->mock('\DateTime')->expect('getLastErrors')->get();
+        $self = $this;
+        $this->assert(
+            function () use ($mock, $self) {
+                $self->assertMock($mock);
+            },
+            throws,
+            '\PHPUnit_Framework_AssertionFailedError'
+        );
+    }
 
-	public function testAssertingASecondaryMock()
-	{
-		$this->mock()->get();
-		$mock2 = $this->mock('\DateTime')
-			->expect('getLastErrors')
-			->get();
-		$self = $this;
-		$this->assert(function () use ($mock2, $self) {
-			$self->assertMock($mock2);
-		}, throws, '\PHPUnit_Framework_AssertionFailedError');
-	}
+    public function testAssertingASecondaryMock()
+    {
+        $this->mock()->get();
+        $mock2 = $this->mock('\DateTime')->expect('getLastErrors')->get();
+        $self = $this;
+        $this->assert(
+            function () use ($mock2, $self) {
+                $self->assertMock($mock2);
+            },
+            throws,
+            '\PHPUnit_Framework_AssertionFailedError'
+        );
+    }
 
-	public function testAssertingAMockDoesNotRemoveItFromTheManager()
-	{
-		$mock1 = $this->mock()->get();
-		$this->mock()->get();
-		$this->assertMock($mock1);
-		$this->assert(count($this->mockManager->getMocks()), equals, 2);
-	}
+    public function testAssertingAMockDoesNotRemoveItFromTheManager()
+    {
+        $mock1 = $this->mock()->get();
+        $this->mock()->get();
+        $this->assertMock($mock1);
+        $this->assert(count($this->mockManager->getMocks()), equals, 2);
+    }
 
-	public function testAssertingAMiddleMock()
-	{
-		$this->mock()->get();
-		$mock2 = $this->mock('\DateTime')
-			->expect('getLastErrors')
-			->get();
-		$this->mock()->get();
-		$self = $this;
-		$this->assert(function () use ($mock2, $self) {
-			$self->assertMock($mock2);
-		}, throws, '\PHPUnit_Framework_AssertionFailedError');
-	}
+    public function testAssertingAMiddleMock()
+    {
+        $this->mock()->get();
+        $mock2 = $this->mock('\DateTime')->expect('getLastErrors')->get();
+        $this->mock()->get();
+        $self = $this;
+        $this->assert(
+            function () use ($mock2, $self) {
+                $self->assertMock($mock2);
+            },
+            throws,
+            '\PHPUnit_Framework_AssertionFailedError'
+        );
+    }
 
-	/**
-	 * @expectedException \PHPUnit_Framework_AssertionFailedError
-	 * @expectedExceptionMessage You cannot assert a mock more than once.
-	 */
-	public function testYouCannotAssertAMockTwice()
-	{
-		$mock = $this->mock()->get();
-		$this->assertMock($mock);
-		$this->assertMock($mock);
-	}
+    /**
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage You cannot assert a mock more than once.
+     */
+    public function testYouCannotAssertAMockTwice()
+    {
+        $mock = $this->mock()->get();
+        $this->assertMock($mock);
+        $this->assertMock($mock);
+    }
 
-	/**
-	 * @expectedException \PHPUnit_Framework_AssertionFailedError
-	 * @expectedExceptionMessage No such mock in mock manager.
-	 */
-	public function testWillThrowExceptionIfMockBeingVerifiedDoesNotExist()
-	{
-		$this->assertMock(new DummyMock());
-	}
+    /**
+     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage No such mock in mock manager.
+     */
+    public function testWillThrowExceptionIfMockBeingVerifiedDoesNotExist()
+    {
+        $this->assertMock(new DummyMock());
+    }
 }

--- a/tests/Concise/Mock/PrototypeBuilderTest.php
+++ b/tests/Concise/Mock/PrototypeBuilderTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Mock;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 // `callable` does not exist in PHP 5.3 and we need it for the prototype below.
 if (version_compare(phpversion(), '5.4', '<')) {
@@ -46,73 +46,121 @@ class PrototypeBuilderTest extends TestCase
     public function testPrototypeIsBuiltFromReflectionMethod()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'foo');
-        $this->assert($this->builder->getPrototype($method), equals, 'public function foo()');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'public function foo()'
+        );
     }
 
     public function testWillRespectPrototypeModifiers()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'bar');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function bar()');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function bar()'
+        );
     }
 
     public function testWillRespectPrototypeArguments()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'baz');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function baz($a, $b)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function baz($a, $b)'
+        );
     }
 
     public function testWillNotReturnAbstractKeywordIfToldNotTo()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'bar');
         $this->builder->hideAbstract = true;
-        $this->assert($this->builder->getPrototype($method), equals, 'protected function bar()');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'protected function bar()'
+        );
     }
 
     public function testWillRespectPrototypeArgumentTypeHinting()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'a');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function a(\DateTime $a)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function a(\DateTime $a)'
+        );
     }
 
     public function testWillRespectPrototypeArgumentDefaultValue()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'b');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function b($a = 123)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function b($a = 123)'
+        );
     }
 
     public function testWillRespectPrototypeArgumentPassByReference()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'c');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function c(&$a)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function c(&$a)'
+        );
     }
 
     public function testWillNotSetADefaultValueForInternalMethods()
     {
         $method = new \ReflectionMethod('\DateTime', 'setTime');
-        $this->assert($this->builder->getPrototype($method), equals, 'public function setTime($hour, $minute, $second = NULL)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'public function setTime($hour, $minute, $second = NULL)'
+        );
     }
 
     public function testArrayHint()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'd');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function d(array $a)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function d(array $a)'
+        );
     }
 
     public function testClosureHint()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'e');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function e(\Closure $a)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function e(\Closure $a)'
+        );
     }
 
     public function testArrayDefaultValue()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'f');
-        $this->assert($this->builder->getPrototype($method), equals, "abstract protected function f(\$a = array (\n))");
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            "abstract protected function f(\$a = array (\n))"
+        );
     }
 
     public function testPrototypeCanBeBuiltWithOnlyAMethodName()
     {
-        $this->assert($this->builder->getPrototypeForNonExistentMethod('foo'), equals, 'public function foo()');
+        $this->assert(
+            $this->builder->getPrototypeForNonExistentMethod('foo'),
+            equals,
+            'public function foo()'
+        );
     }
 
     /**
@@ -130,6 +178,10 @@ class PrototypeBuilderTest extends TestCase
     public function testCallableHint()
     {
         $method = new \ReflectionMethod('\Concise\Mock\MyClass', 'g');
-        $this->assert($this->builder->getPrototype($method), equals, 'abstract protected function g(callable $a)');
+        $this->assert(
+            $this->builder->getPrototype($method),
+            equals,
+            'abstract protected function g(callable $a)'
+        );
     }
 }

--- a/tests/Concise/Services/AssertionBuilderTest.php
+++ b/tests/Concise/Services/AssertionBuilderTest.php
@@ -2,20 +2,25 @@
 
 namespace Concise\Services;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class AssertionBuilderTest extends TestCase
 {
     public function testCanFindAssertionWithArguments()
     {
         $assertion = $this->getAssertionWithArgs(array(123, 'equals', 123));
-        $this->assert($assertion->getMatcher(), instance_of, '\Concise\Matcher\Equals');
+        $this->assert(
+            $assertion->getMatcher(),
+            instance_of,
+            '\Concise\Matcher\Equals'
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage No such matcher for syntax '? array ?' or 'equals ? string'.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage No such matcher for syntax '? array ?' or
+     *     'equals ? string'.
+     */
     public function testWillThrowExceptionIfAssertionCannotBeFound()
     {
         $builder = new AssertionBuilder(array('equals', 'array', 'string'));
@@ -25,25 +30,42 @@ class AssertionBuilderTest extends TestCase
     public function testAssertionBuilderWillAcceptTrue()
     {
         $assertion = $this->getAssertionWithArgs(array(true));
-        $this->assert($assertion->getMatcher(), instance_of, '\Concise\Matcher\True');
+        $this->assert(
+            $assertion->getMatcher(),
+            instance_of,
+            '\Concise\Matcher\True'
+        );
     }
 
     public function testAssertionBuilderWillAcceptFalse()
     {
         $assertion = $this->getAssertionWithArgs(array(false));
-        $this->assert($assertion->getMatcher(), instance_of, '\Concise\Matcher\False');
+        $this->assert(
+            $assertion->getMatcher(),
+            instance_of,
+            '\Concise\Matcher\False'
+        );
     }
 
     public function testAssertionBuilderWillAcceptTrueFollowedByOtherArguments()
     {
         $assertion = $this->getAssertionWithArgs(array(true, 'is true'));
-        $this->assert($assertion->getMatcher(), not_instance_of, '\Concise\Matcher\True');
+        $this->assert(
+            $assertion->getMatcher(),
+            not_instance_of,
+            '\Concise\Matcher\True'
+        );
     }
 
-    public function testAssertionBuilderWillAcceptFalseFollowedByOtherArguments()
+    public function testAssertionBuilderWillAcceptFalseFollowedByOtherArguments(
+    )
     {
         $assertion = $this->getAssertionWithArgs(array(false, 'is false'));
-        $this->assert($assertion->getMatcher(), not_instance_of, '\Concise\Matcher\False');
+        $this->assert(
+            $assertion->getMatcher(),
+            not_instance_of,
+            '\Concise\Matcher\False'
+        );
     }
 
     protected function getAssertionWithArgs(array $args)

--- a/tests/Concise/Services/AssertionBuilderTest.php
+++ b/tests/Concise/Services/AssertionBuilderTest.php
@@ -57,8 +57,7 @@ class AssertionBuilderTest extends TestCase
         );
     }
 
-    public function testAssertionBuilderWillAcceptFalseFollowedByOtherArguments(
-    )
+    public function testAssertionBuilderWillAcceptFalseFollowedByOtherArguments()
     {
         $assertion = $this->getAssertionWithArgs(array(false, 'is false'));
         $this->assert(

--- a/tests/Concise/Services/CharacterConverterTest.php
+++ b/tests/Concise/Services/CharacterConverterTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Services;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class CharacterConverterTest extends TestCase
 {
@@ -24,11 +24,15 @@ class CharacterConverterTest extends TestCase
     }
 
     /**
-	 * @dataProvider stringData
-	 */
+     * @dataProvider stringData
+     */
     public function testConvertingCharacterToEscapeCharacter($letter, $outcome)
     {
         $converter = new CharacterConverter();
-        $this->assert($converter->convertEscapedCharacter($letter), exactly_equals, $outcome);
+        $this->assert(
+            $converter->convertEscapedCharacter($letter),
+            exactly_equals,
+            $outcome
+        );
     }
 }

--- a/tests/Concise/Services/MatcherSyntaxAndDescriptionTest.php
+++ b/tests/Concise/Services/MatcherSyntaxAndDescriptionTest.php
@@ -13,34 +13,43 @@ class MatcherSyntaxAndDescriptionTest extends \Concise\TestCase
 
     public function testNoDescriptions()
     {
-        $this->assertProcess(array(
-            '? equals ?',
-            '? is equal to ?'
-        ), array(
-            '? equals ?'      => null,
-            '? is equal to ?' => null
-        ));
+        $this->assertProcess(
+            array(
+                '? equals ?',
+                '? is equal to ?'
+            ),
+            array(
+                '? equals ?' => null,
+                '? is equal to ?' => null
+            )
+        );
     }
 
     public function testAllDescriptions()
     {
-        $this->assertProcess(array(
-            '? equals ?'      => 'foo',
-            '? is equal to ?' => 'bar'
-        ), array(
-            '? equals ?'      => 'foo',
-            '? is equal to ?' => 'bar'
-        ));
+        $this->assertProcess(
+            array(
+                '? equals ?' => 'foo',
+                '? is equal to ?' => 'bar'
+            ),
+            array(
+                '? equals ?' => 'foo',
+                '? is equal to ?' => 'bar'
+            )
+        );
     }
 
     public function testMixedDescriptions()
     {
-        $this->assertProcess(array(
-            '? equals ?',
-            '? is equal to ?' => 'bar'
-        ), array(
-            '? equals ?'      => null,
-            '? is equal to ?' => 'bar'
-        ));
+        $this->assertProcess(
+            array(
+                '? equals ?',
+                '? is equal to ?' => 'bar'
+            ),
+            array(
+                '? equals ?' => null,
+                '? is equal to ?' => 'bar'
+            )
+        );
     }
 }

--- a/tests/Concise/Services/NumberToTimesConverterTest.php
+++ b/tests/Concise/Services/NumberToTimesConverterTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Services;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class NumberToTimesConverterTest extends TestCase
 {
@@ -46,7 +46,11 @@ class NumberToTimesConverterTest extends TestCase
 
     public function testMethodDefaultsToExactly()
     {
-        $this->assert($this->converter->convertToMethod(123), equals, 'exactly(123)');
+        $this->assert(
+            $this->converter->convertToMethod(123),
+            equals,
+            'exactly(123)'
+        );
     }
 
     public function testMethodForZeroIsNever()

--- a/tests/Concise/Services/SyntaxRendererTest.php
+++ b/tests/Concise/Services/SyntaxRendererTest.php
@@ -2,8 +2,8 @@
 
 namespace Concise\Services;
 
-use Concise\TestCase;
 use Colors\Color;
+use Concise\TestCase;
 
 class SyntaxRendererTest extends TestCase
 {
@@ -22,8 +22,8 @@ class SyntaxRendererTest extends TestCase
     {
         $data = array(1, '2', 3.1);
         $c = new Color();
-        $expected = (string) $c('1')->red . ' is ' . (string) $c('"2"')->yellow
-            . ' bla ' . (string) $c(3.1)->magenta;
+        $expected = (string)$c('1')->red . ' is ' . (string)$c('"2"')->yellow .
+            ' bla ' . (string)$c(3.1)->magenta;
         $this->assert(
             $expected,
             equals,

--- a/tests/Concise/Services/TimeFormatterTest.php
+++ b/tests/Concise/Services/TimeFormatterTest.php
@@ -37,7 +37,11 @@ class TimeFormatterTest extends TestCase
      */
     public function testFormattingLong($seconds, $expected)
     {
-        $this->assert($this->formatter->format($seconds, false), equals, $expected);
+        $this->assert(
+            $this->formatter->format($seconds, false),
+            equals,
+            $expected
+        );
     }
 
     /**
@@ -46,6 +50,10 @@ class TimeFormatterTest extends TestCase
      */
     public function testFormattingShort($seconds, $_, $expected)
     {
-        $this->assert($this->formatter->format($seconds, true), equals, $expected);
+        $this->assert(
+            $this->formatter->format($seconds, true),
+            equals,
+            $expected
+        );
     }
 }

--- a/tests/Concise/Services/ValueDescriptorTest.php
+++ b/tests/Concise/Services/ValueDescriptorTest.php
@@ -35,11 +35,19 @@ class ValueDescriptorTest extends \Concise\TestCase
 
     public function testDescriptionOfObject()
     {
-        $this->assert($this->descriptor->describe($this), equals, 'Concise\Services\ValueDescriptorTest');
+        $this->assert(
+            $this->descriptor->describe($this),
+            equals,
+            'Concise\Services\ValueDescriptorTest'
+        );
     }
 
     public function testDescriptionOfResource()
     {
-        $this->assert($this->descriptor->describe(fopen('.', 'r')), equals, 'resource');
+        $this->assert(
+            $this->descriptor->describe(fopen('.', 'r')),
+            equals,
+            'resource'
+        );
     }
 }

--- a/tests/Concise/Services/ValueRendererTest.php
+++ b/tests/Concise/Services/ValueRendererTest.php
@@ -3,7 +3,6 @@
 namespace Concise\Services;
 
 use Colors\Color;
-use Concise\Console\Theme\DefaultTheme;
 
 class ValueRendererTest extends \Concise\TestCase
 {
@@ -33,14 +32,22 @@ class ValueRendererTest extends \Concise\TestCase
 
     public function testArrayValueRendersAsJson()
     {
-        $this->assert($this->renderer->render(array(123, "abc")), equals, "[\n  123,\n  \"abc\"\n]");
+        $this->assert(
+            $this->renderer->render(array(123, "abc")),
+            equals,
+            "[\n  123,\n  \"abc\"\n]"
+        );
     }
 
     public function testObjectValueRendersAsJson()
     {
         $obj = new \stdClass();
         $obj->a = 123;
-        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":123\n}");
+        $this->assert(
+            $this->renderer->render($obj),
+            equals,
+            "stdClass:{\n  \"a\":123\n}"
+        );
     }
 
     public function testTrueValueRendersAsTrue()
@@ -67,7 +74,14 @@ class ValueRendererTest extends \Concise\TestCase
 
     public function testFunctionRendersAsString()
     {
-        $this->assert($this->renderer->render(function () {}), equals, 'function');
+        $this->assert(
+            $this->renderer->render(
+                function () {
+                }
+            ),
+            equals,
+            'function'
+        );
     }
 
     public function testRenderAllMethodWithZeroElements()
@@ -87,14 +101,18 @@ class ValueRendererTest extends \Concise\TestCase
 
     public function testRenderAllWithStrings()
     {
-        $this->assert($this->renderer->renderAll(array('foo')), equals, '"foo"');
+        $this->assert(
+            $this->renderer->renderAll(array('foo')),
+            equals,
+            '"foo"'
+        );
     }
 
     protected function getThemeForValue(array $colors)
     {
-        return $this->mock('Concise\Console\Theme\DefaultTheme')
-                      ->stub(array('getTheme' => $colors))
-                      ->get();
+        return $this->mock('Concise\Console\Theme\DefaultTheme')->stub(
+                array('getTheme' => $colors)
+            )->get();
     }
 
     public function testIntegersWillBeColoredWhenAThemeIsSpecified()
@@ -102,7 +120,11 @@ class ValueRendererTest extends \Concise\TestCase
         $theme = $this->getThemeForValue(array('value.integer' => 'magenta'));
         $this->renderer->setTheme($theme);
         $c = new Color();
-        $this->assert($this->renderer->render(123), equals, (string) $c(123)->magenta);
+        $this->assert(
+            $this->renderer->render(123),
+            equals,
+            (string)$c(123)->magenta
+        );
     }
 
     public function testFloatingPointsWillBeColoredWhenAThemeIsSpecified()
@@ -110,7 +132,11 @@ class ValueRendererTest extends \Concise\TestCase
         $theme = $this->getThemeForValue(array('value.float' => 'red'));
         $this->renderer->setTheme($theme);
         $c = new Color();
-        $this->assert($this->renderer->render(12.3), equals, (string) $c(12.3)->red);
+        $this->assert(
+            $this->renderer->render(12.3),
+            equals,
+            (string)$c(12.3)->red
+        );
     }
 
     public function testStringsWillBeColoredWhenAThemeIsSpecified()
@@ -118,7 +144,11 @@ class ValueRendererTest extends \Concise\TestCase
         $theme = $this->getThemeForValue(array('value.string' => 'green'));
         $this->renderer->setTheme($theme);
         $c = new Color();
-        $this->assert($this->renderer->render("12.3"), equals, (string) $c("\"12.3\"")->green);
+        $this->assert(
+            $this->renderer->render("12.3"),
+            equals,
+            (string)$c("\"12.3\"")->green
+        );
     }
 
     public function testClosureWillBeColoredWhenAThemeIsSpecified()
@@ -126,29 +156,48 @@ class ValueRendererTest extends \Concise\TestCase
         $theme = $this->getThemeForValue(array('value.closure' => 'blue'));
         $this->renderer->setTheme($theme);
         $c = new Color();
-        $this->assert($this->renderer->render(function () {}), equals, (string) $c("function")->blue);
+        $this->assert(
+            $this->renderer->render(
+                function () {
+                }
+            ),
+            equals,
+            (string)$c("function")->blue
+        );
     }
 
     public function testObjectKeysWillBeColoredWhenAThemeIsSpecified()
     {
-        $theme = $this->getThemeForValue(array('value.string' => 'green', 'value.integer' => 'yellow'));
+        $theme = $this->getThemeForValue(
+            array('value.string' => 'green', 'value.integer' => 'yellow')
+        );
         $this->renderer->setTheme($theme);
         $c = new Color();
 
         $obj = new \stdClass();
         $obj->a = 123;
-        $this->assert($this->renderer->render($obj), contains_string, (string) $c('"a"')->green);
+        $this->assert(
+            $this->renderer->render($obj),
+            contains_string,
+            (string)$c('"a"')->green
+        );
     }
 
     public function testObjectValuesWillBeColoredWhenAThemeIsSpecified()
     {
-        $theme = $this->getThemeForValue(array('value.string' => 'yellow', 'value.integer' => 'green'));
+        $theme = $this->getThemeForValue(
+            array('value.string' => 'yellow', 'value.integer' => 'green')
+        );
         $this->renderer->setTheme($theme);
         $c = new Color();
 
         $obj = new \stdClass();
         $obj->a = 123;
-        $this->assert($this->renderer->render($obj), contains_string, (string) $c(123)->green);
+        $this->assert(
+            $this->renderer->render($obj),
+            contains_string,
+            (string)$c(123)->green
+        );
     }
 
     public function testArrayKeysWillBeColoredWhenAThemeIsSpecified()
@@ -157,7 +206,11 @@ class ValueRendererTest extends \Concise\TestCase
         $this->renderer->setTheme($theme);
         $c = new Color();
 
-        $this->assert($this->renderer->render(array('bar')), contains_string, (string) $c('"bar"')->green);
+        $this->assert(
+            $this->renderer->render(array('bar')),
+            contains_string,
+            (string)$c('"bar"')->green
+        );
     }
 
     public function testMultipleObjectValuesRendersAsJson()
@@ -165,22 +218,38 @@ class ValueRendererTest extends \Concise\TestCase
         $obj = new \stdClass();
         $obj->a = 123;
         $obj->b = 456;
-        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":123,\n  \"b\":456\n}");
+        $this->assert(
+            $this->renderer->render($obj),
+            equals,
+            "stdClass:{\n  \"a\":123,\n  \"b\":456\n}"
+        );
     }
 
     public function testMultipleArrayValuesRendersAsJson()
     {
-        $this->assert($this->renderer->render(array(1, 2)), equals, "[\n  1,\n  2\n]");
+        $this->assert(
+            $this->renderer->render(array(1, 2)),
+            equals,
+            "[\n  1,\n  2\n]"
+        );
     }
 
     public function testAssociativeArrayRendersAsJson()
     {
-        $this->assert($this->renderer->render(array('foo' => 'bar')), equals, "{\n  \"foo\":\"bar\"\n}");
+        $this->assert(
+            $this->renderer->render(array('foo' => 'bar')),
+            equals,
+            "{\n  \"foo\":\"bar\"\n}"
+        );
     }
 
     public function testNumericArrayKeysAlwaysRenderAsStrings()
     {
-        $this->assert($this->renderer->render(array(123 => 'bar')), equals, "{\n  \"123\":\"bar\"\n}");
+        $this->assert(
+            $this->renderer->render(array(123 => 'bar')),
+            equals,
+            "{\n  \"123\":\"bar\"\n}"
+        );
     }
 
     public function testNestedObjectsHideTypeHint()
@@ -188,7 +257,11 @@ class ValueRendererTest extends \Concise\TestCase
         $obj = new \stdClass();
         $obj->a = new \stdClass();
         $obj->a->b = 456;
-        $this->assert($this->renderer->render($obj), equals, "stdClass:{\n  \"a\":{\n    \"b\":456\n  }\n}");
+        $this->assert(
+            $this->renderer->render($obj),
+            equals,
+            "stdClass:{\n  \"a\":{\n    \"b\":456\n  }\n}"
+        );
     }
 
     public function testNullWillBeColoredWhenAThemeIsSpecified()
@@ -197,7 +270,11 @@ class ValueRendererTest extends \Concise\TestCase
         $this->renderer->setTheme($theme);
         $c = new Color();
 
-        $this->assert($this->renderer->render(null), contains_string, (string) $c('null')->green);
+        $this->assert(
+            $this->renderer->render(null),
+            contains_string,
+            (string)$c('null')->green
+        );
     }
 
     public function testBooleanWillBeColoredWhenAThemeIsSpecified()
@@ -206,7 +283,11 @@ class ValueRendererTest extends \Concise\TestCase
         $this->renderer->setTheme($theme);
         $c = new Color();
 
-        $this->assert($this->renderer->render(true), contains_string, (string) $c('true')->red);
+        $this->assert(
+            $this->renderer->render(true),
+            contains_string,
+            (string)$c('true')->red
+        );
     }
 
     public function testDefaultMaximumDepthIsTen()
@@ -216,24 +297,37 @@ class ValueRendererTest extends \Concise\TestCase
 
     public function testMaximumDepthStopsRendererFromConsumingTooMuchMemory()
     {
-        $renderer = $this->niceMock('Concise\Services\ValueRenderer')
-                         ->stub(array('getMaximumDepth' => 2))
-                         ->get();
+        $renderer = $this->niceMock('Concise\Services\ValueRenderer')->stub(
+                array('getMaximumDepth' => 2)
+            )->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}');
-        $this->assert($renderer->render($obj), equals, "stdClass:{\n  \"a\":{\n    \"a\":...\n  }\n}");
+        $this->assert(
+            $renderer->render($obj),
+            equals,
+            "stdClass:{\n  \"a\":{\n    \"a\":...\n  }\n}"
+        );
     }
 
-    public function testMaximumDepthStopsRendererFromConsumingTooMuchMemoryForArrays()
+    public function testMaximumDepthStopsRendererFromConsumingTooMuchMemoryForArrays(
+    )
     {
-        $renderer = $this->niceMock('Concise\Services\ValueRenderer')
-                         ->stub(array('getMaximumDepth' => 2))
-                         ->get();
+        $renderer = $this->niceMock('Concise\Services\ValueRenderer')->stub(
+                array('getMaximumDepth' => 2)
+            )->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}', true);
-        $this->assert($renderer->render($obj), equals, "{\n  \"a\":{\n    \"a\":...\n  }\n}");
+        $this->assert(
+            $renderer->render($obj),
+            equals,
+            "{\n  \"a\":{\n    \"a\":...\n  }\n}"
+        );
     }
 
     public function testRenderAnythingConstant()
     {
-        $this->assert($this->renderer->render(self::ANYTHING), equals, '<ANYTHING>');
+        $this->assert(
+            $this->renderer->render(self::ANYTHING),
+            equals,
+            '<ANYTHING>'
+        );
     }
 }

--- a/tests/Concise/Services/ValueRendererTest.php
+++ b/tests/Concise/Services/ValueRendererTest.php
@@ -111,8 +111,8 @@ class ValueRendererTest extends \Concise\TestCase
     protected function getThemeForValue(array $colors)
     {
         return $this->mock('Concise\Console\Theme\DefaultTheme')->stub(
-                array('getTheme' => $colors)
-            )->get();
+            array('getTheme' => $colors)
+        )->get();
     }
 
     public function testIntegersWillBeColoredWhenAThemeIsSpecified()
@@ -298,8 +298,8 @@ class ValueRendererTest extends \Concise\TestCase
     public function testMaximumDepthStopsRendererFromConsumingTooMuchMemory()
     {
         $renderer = $this->niceMock('Concise\Services\ValueRenderer')->stub(
-                array('getMaximumDepth' => 2)
-            )->get();
+            array('getMaximumDepth' => 2)
+        )->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}');
         $this->assert(
             $renderer->render($obj),
@@ -308,12 +308,11 @@ class ValueRendererTest extends \Concise\TestCase
         );
     }
 
-    public function testMaximumDepthStopsRendererFromConsumingTooMuchMemoryForArrays(
-    )
+    public function testMaximumDepthStopsRendererFromConsumingTooMuchMemoryForArrays()
     {
         $renderer = $this->niceMock('Concise\Services\ValueRenderer')->stub(
-                array('getMaximumDepth' => 2)
-            )->get();
+            array('getMaximumDepth' => 2)
+        )->get();
         $obj = json_decode('{"a":{"a":{"a":"b"}}}', true);
         $this->assert(
             $renderer->render($obj),

--- a/tests/Concise/Syntax/LexerClassnameTest.php
+++ b/tests/Concise/Syntax/LexerClassnameTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Syntax;
 
-use \Concise\Syntax\Token\Attribute;
+use Concise\Syntax\Token\Attribute;
 
 class LexerClassnameTest extends LexerTestCase
 {

--- a/tests/Concise/Syntax/LexerTest.php
+++ b/tests/Concise/Syntax/LexerTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Syntax;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class LexerTest extends TestCase
 {
@@ -36,8 +36,8 @@ class LexerTest extends TestCase
     }
 
     /**
-	 * @dataProvider tokenData
-	 */
+     * @dataProvider tokenData
+     */
     public function testReadKeywordToken($string, $expectedToken)
     {
         $lexer = new Lexer();
@@ -77,19 +77,23 @@ class LexerTest extends TestCase
     }
 
     /**
-	 * @dataProvider stringData
-	 */
+     * @dataProvider stringData
+     */
     public function testTokenizerUnderstandsStrings($string, $expected)
     {
         $lexer = new Lexer();
         $result = $lexer->parse($string);
-        $this->assert(array(new Token\Value($expected)), equals, $result['tokens']);
+        $this->assert(
+            array(new Token\Value($expected)),
+            equals,
+            $result['tokens']
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Expected " before end of string.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected " before end of string.
+     */
     public function testLexerThrowsExceptionIfDoubleQuotedStringIsNotClosed()
     {
         $lexer = new Lexer();
@@ -97,9 +101,9 @@ class LexerTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Expected ' before end of string.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected ' before end of string.
+     */
     public function testLexerThrowsExceptionIfSingleQuotedStringIsNotClosed()
     {
         $lexer = new Lexer();
@@ -107,9 +111,9 @@ class LexerTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Invalid JSON: [abc
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid JSON: [abc
+     */
     public function testLexerThrowsExceptionIfArrayIsNotValid()
     {
         $lexer = new Lexer();
@@ -120,14 +124,22 @@ class LexerTest extends TestCase
     {
         $lexer = new Lexer();
         $result = $lexer->parse('?:int');
-        $this->assert($result['arguments'][0]->getAcceptedTypes(), equals, array('int'));
+        $this->assert(
+            $result['arguments'][0]->getAcceptedTypes(),
+            equals,
+            array('int')
+        );
     }
 
     public function testLexerCanExtractExpectedTypesFromSyntax()
     {
         $lexer = new Lexer();
         $result = $lexer->parse('?:int,float');
-        $this->assert($result['arguments'][0]->getAcceptedTypes(), equals, array('int', 'float'));
+        $this->assert(
+            $result['arguments'][0]->getAcceptedTypes(),
+            equals,
+            array('int', 'float')
+        );
     }
 
     public function testLexerWillNotPutExpectedTypesInAttributeValue()
@@ -138,9 +150,9 @@ class LexerTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Invalid JSON: [abc:123]
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid JSON: [abc:123]
+     */
     public function testLexerThrowsExceptionIfAssociativeArrayIsNotValid()
     {
         $lexer = new Lexer();

--- a/tests/Concise/Syntax/LexerTestCase.php
+++ b/tests/Concise/Syntax/LexerTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Syntax;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 abstract class LexerTestCase extends TestCase
 {
@@ -10,8 +10,8 @@ abstract class LexerTestCase extends TestCase
     protected $lexer;
 
     /**
-	 * @var array
-	 */
+     * @var array
+     */
     protected $parsed;
 
     public function setUp()
@@ -33,7 +33,11 @@ abstract class LexerTestCase extends TestCase
 
     public function testLexerWillReturnArgumentsForString()
     {
-        $this->assert($this->expectedArguments(), equals, $this->parsed['arguments']);
+        $this->assert(
+            $this->expectedArguments(),
+            equals,
+            $this->parsed['arguments']
+        );
     }
 
     abstract protected function expectedTokens();

--- a/tests/Concise/Syntax/MatcherParserTest.php
+++ b/tests/Concise/Syntax/MatcherParserTest.php
@@ -2,8 +2,8 @@
 
 namespace Concise\Syntax;
 
-use \Concise\TestCase;
-use \Concise\Matcher\AbstractMatcher;
+use Concise\Matcher\AbstractMatcher;
+use Concise\TestCase;
 
 class MatcherParserStub extends MatcherParser
 {
@@ -51,27 +51,33 @@ class MatcherParserTest extends TestCase
 
     public function testRegisteringANewMatcherReturnsTrue()
     {
-        $this->assert($this->parser->registerMatcher(new \Concise\Matcher\Equals()));
+        $this->assert(
+            $this->parser->registerMatcher(new \Concise\Matcher\Equals())
+        );
     }
 
     public function testGetInstanceIsASingleton()
     {
-        $this->assert(MatcherParser::getInstance(), exactly_equals, MatcherParser::getInstance());
+        $this->assert(
+            MatcherParser::getInstance(),
+            exactly_equals,
+            MatcherParser::getInstance()
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage No such matcher for syntax 'something'.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage No such matcher for syntax 'something'.
+     */
     public function testGetMatcherForSyntaxThrowsExceptionIfNoMatchersAreFound()
     {
         $this->parser->getMatcherForSyntax('something');
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage registerMatchers() can only be called once.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage registerMatchers() can only be called once.
+     */
     public function testRegisterMatchersCanOnlyBeCalledOnce()
     {
         $parser = new MatcherParserStub();
@@ -120,9 +126,9 @@ class MatcherParserTest extends TestCase
 
     public function testGetKeywordsAreOnlyGeneratedOnce()
     {
-        $parser = $this->niceMock('\Concise\Syntax\MatcherParser')
-                       ->expect('getRawKeywords')->once()->andReturn(array('a'))
-                       ->get();
+        $parser = $this->niceMock('\Concise\Syntax\MatcherParser')->expect(
+                'getRawKeywords'
+            )->once()->andReturn(array('a'))->get();
 
         $parser->getKeywords();
         $parser->getKeywords();
@@ -131,47 +137,59 @@ class MatcherParserTest extends TestCase
     public function testGetAllSyntaxesContainsItemsFromDifferentMatchers()
     {
         $syntaxes = MatcherParser::getInstance()->getAllMatcherDescriptions();
-        $this->assert($syntaxes, has_keys, array('? is null', '? is equal to ?'));
+        $this->assert(
+            $syntaxes,
+            has_keys,
+            array('? is null', '? is equal to ?')
+        );
     }
 
     public function testCanMatchSyntaxWithExpectedTypes()
     {
-        $matcher = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('?:int foobar ?:float'));
+        $matcher = $this->getAbstractMatcherMockWithSupportedSyntaxes(
+            array('?:int foobar ?:float')
+        );
         $this->parser->registerMatcher($matcher);
         $assertion = $this->parser->compile('123 foobar 1.23', array());
         $this->assert($matcher, exactly_equals, $assertion->getMatcher());
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Argument 2 (123) must be regex.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Argument 2 (123) must be regex.
+     */
     public function testWillValidateAllAttributes()
     {
         $this->assert('"abc" does not match regex 123');
     }
 
-    public function testAnythingThatStartsWithAQuestionMarkWillNotBeConsideredAKeyword()
+    public function testAnythingThatStartsWithAQuestionMarkWillNotBeConsideredAKeyword(
+    )
     {
-        $matcher = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('?:int foobar ?:float'));
+        $matcher = $this->getAbstractMatcherMockWithSupportedSyntaxes(
+            array('?:int foobar ?:float')
+        );
         $this->parser->registerMatcher($matcher);
         $this->assert($this->parser->getKeywords(), has_value, 'foobar');
     }
 
     /**
-	 * @param string[] $supportedSyntaxes
-	 */
-    protected function getAbstractMatcherMockWithSupportedSyntaxes($supportedSyntaxes)
-    {
-        return $this->mock('\Concise\Matcher\AbstractMatcher')
-                    ->stub(array('supportedSyntaxes' => $supportedSyntaxes))
-                    ->get();
+     * @param string[] $supportedSyntaxes
+     */
+    protected function getAbstractMatcherMockWithSupportedSyntaxes(
+        $supportedSyntaxes
+    ) {
+        return $this->mock('\Concise\Matcher\AbstractMatcher')->stub(
+                array('supportedSyntaxes' => $supportedSyntaxes)
+            )->get();
     }
 
     public function testKeywordCacheIsDroppedWhenAMatcherIsAdded()
     {
-        $matcher1 = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
-        $matcher2 = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('bar'));
+        $matcher1 =
+            $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
+        $matcher2 =
+            $this->getAbstractMatcherMockWithSupportedSyntaxes(array('bar'));
         $this->parser->registerMatcher($matcher1);
         $keywords1 = $this->parser->getKeywords();
         $this->parser->registerMatcher($matcher2);
@@ -180,21 +198,23 @@ class MatcherParserTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Syntax 'foo' is already declared.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Syntax 'foo' is already declared.
+     */
     public function testAddingAMatcherWithDuplicateSyntaxThrowsException()
     {
-        $matcher1 = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
-        $matcher2 = $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
+        $matcher1 =
+            $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
+        $matcher2 =
+            $this->getAbstractMatcherMockWithSupportedSyntaxes(array('foo'));
         $this->parser->registerMatcher($matcher1);
         $this->parser->registerMatcher($matcher2);
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage All assertions ('Capitols') must be lower case.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage All assertions ('Capitols') must be lower case.
+     */
     public function testUsingCapitolsInAssertionNamesThrowsException()
     {
         $matcher = new MatcherParser();
@@ -216,7 +236,8 @@ class MatcherParserTest extends TestCase
     public function testOnErrorIsReturnedWhenLocatingTheMatcher()
     {
         $parser = MatcherParser::getInstance();
-        $matcher = $parser->getMatcherForSyntax('? equals ? on error ?', array(''));
+        $matcher =
+            $parser->getMatcherForSyntax('? equals ? on error ?', array(''));
         $this->assert($matcher, has_key, 'on_error');
     }
 
@@ -230,14 +251,18 @@ class MatcherParserTest extends TestCase
     public function testOnErrorIsReturnedFromData()
     {
         $parser = MatcherParser::getInstance();
-        $matcher = $parser->getMatcherForSyntax('? equals ? on error ?', array('foo'));
+        $matcher =
+            $parser->getMatcherForSyntax('? equals ? on error ?', array('foo'));
         $this->assert($matcher['on_error'], equals, 'foo');
     }
 
     public function testOnErrorMustBeTheLastData()
     {
         $parser = MatcherParser::getInstance();
-        $matcher = $parser->getMatcherForSyntax('? equals ? on error ?', array('foo', 'bar'));
+        $matcher = $parser->getMatcherForSyntax(
+            '? equals ? on error ?',
+            array('foo', 'bar')
+        );
         $this->assert($matcher['on_error'], equals, 'bar');
     }
 

--- a/tests/Concise/Syntax/MatcherParserTest.php
+++ b/tests/Concise/Syntax/MatcherParserTest.php
@@ -127,8 +127,8 @@ class MatcherParserTest extends TestCase
     public function testGetKeywordsAreOnlyGeneratedOnce()
     {
         $parser = $this->niceMock('\Concise\Syntax\MatcherParser')->expect(
-                'getRawKeywords'
-            )->once()->andReturn(array('a'))->get();
+            'getRawKeywords'
+        )->once()->andReturn(array('a'))->get();
 
         $parser->getKeywords();
         $parser->getKeywords();
@@ -163,8 +163,7 @@ class MatcherParserTest extends TestCase
         $this->assert('"abc" does not match regex 123');
     }
 
-    public function testAnythingThatStartsWithAQuestionMarkWillNotBeConsideredAKeyword(
-    )
+    public function testAnythingThatStartsWithAQuestionMarkWillNotBeConsideredAKeyword()
     {
         $matcher = $this->getAbstractMatcherMockWithSupportedSyntaxes(
             array('?:int foobar ?:float')
@@ -180,8 +179,8 @@ class MatcherParserTest extends TestCase
         $supportedSyntaxes
     ) {
         return $this->mock('\Concise\Matcher\AbstractMatcher')->stub(
-                array('supportedSyntaxes' => $supportedSyntaxes)
-            )->get();
+            array('supportedSyntaxes' => $supportedSyntaxes)
+        )->get();
     }
 
     public function testKeywordCacheIsDroppedWhenAMatcherIsAdded()

--- a/tests/Concise/Syntax/NoMatcherFoundExceptionTest.php
+++ b/tests/Concise/Syntax/NoMatcherFoundExceptionTest.php
@@ -8,7 +8,11 @@ class NoMatcherFoundExceptionTest extends TestCase
 {
     public function testExtendsException()
     {
-        $this->assert(new NoMatcherFoundException(array()), instance_of, '\Exception');
+        $this->assert(
+            new NoMatcherFoundException(array()),
+            instance_of,
+            '\Exception'
+        );
     }
 
     public function testSyntaxCanBeSetInConstructor()
@@ -20,6 +24,10 @@ class NoMatcherFoundExceptionTest extends TestCase
     public function testExceptionMessage()
     {
         $e = new NoMatcherFoundException(array('? foo ?'));
-        $this->assert($e->getMessage(), equals, "No such matcher for syntax '? foo ?'.");
+        $this->assert(
+            $e->getMessage(),
+            equals,
+            "No such matcher for syntax '? foo ?'."
+        );
     }
 }

--- a/tests/Concise/Syntax/TokenTest.php
+++ b/tests/Concise/Syntax/TokenTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise\Syntax;
 
-use \Concise\TestCase;
+use Concise\TestCase;
 
 class TokenTest extends TestCase
 {
@@ -21,6 +21,6 @@ class TokenTest extends TestCase
     public function testRenderAsStringUsesValue()
     {
         $attribute = new Token\Value('abc');
-        $this->assert((string) $attribute, equals, 'abc');
+        $this->assert((string)$attribute, equals, 'abc');
     }
 }

--- a/tests/Concise/TestCaseExternalTest.php
+++ b/tests/Concise/TestCaseExternalTest.php
@@ -46,10 +46,14 @@ class TestCaseExternalTest extends TestCase
 
     public function testAnExternalRunnerWillThrowAnExceptionOnFailure()
     {
-        $this->assert(function () {
-            $suite = new MyTinyTestSuite();
-            $suite->checkSomethingElse();
-        }, throws, "PHPUnit_Framework_AssertionFailedError");
+        $this->assert(
+            function () {
+                $suite = new MyTinyTestSuite();
+                $suite->checkSomethingElse();
+            },
+            throws,
+            "PHPUnit_Framework_AssertionFailedError"
+        );
     }
 
     public function testAnExternalRunnerCanUseAssertThat()

--- a/tests/Concise/TestCaseMockTest.php
+++ b/tests/Concise/TestCaseMockTest.php
@@ -35,8 +35,7 @@ class TestCaseMockTest extends TestCase
         $this->assert(count($this->getMockManager()->getMocks()), equals, 2);
     }
 
-    public function testCallingDoneTwiceWillGenerateTwoMocksAndBothWillBeRegistered(
-    )
+    public function testCallingDoneTwiceWillGenerateTwoMocksAndBothWillBeRegistered()
     {
         $mockTemplate = $this->mock();
         $mockTemplate->get();

--- a/tests/Concise/TestCaseMockTest.php
+++ b/tests/Concise/TestCaseMockTest.php
@@ -9,7 +9,11 @@ class TestCaseMockTest extends TestCase
 {
     public function testMocksAreResetInTheSetup()
     {
-        $this->assert($this->getMockManager()->getMocks(), exactly_equals, array());
+        $this->assert(
+            $this->getMockManager()->getMocks(),
+            exactly_equals,
+            array()
+        );
     }
 
     public function testCreatingAMockAddsItToTheMocks()
@@ -31,7 +35,8 @@ class TestCaseMockTest extends TestCase
         $this->assert(count($this->getMockManager()->getMocks()), equals, 2);
     }
 
-    public function testCallingDoneTwiceWillGenerateTwoMocksAndBothWillBeRegistered()
+    public function testCallingDoneTwiceWillGenerateTwoMocksAndBothWillBeRegistered(
+    )
     {
         $mockTemplate = $this->mock();
         $mockTemplate->get();

--- a/tests/Concise/TestCasePartialMockTest.php
+++ b/tests/Concise/TestCasePartialMockTest.php
@@ -29,7 +29,11 @@ class TestCasePartialMockTest extends TestCase
     public function testPartialMockReturnsMockBuilder()
     {
         $instance = new DateTime();
-        $this->assert($this->partialMock($instance), instance_of, '\Concise\Mock\MockBuilder');
+        $this->assert(
+            $this->partialMock($instance),
+            instance_of,
+            '\Concise\Mock\MockBuilder'
+        );
     }
 
     /**
@@ -56,7 +60,8 @@ class TestCasePartialMockTest extends TestCase
         $this->assert($this->getProperty($mock, 'public'), equals, 'yes');
     }
 
-    public function testPartialMockWillInheritProtectedObjectValuesToMaintainState()
+    public function testPartialMockWillInheritProtectedObjectValuesToMaintainState(
+    )
     {
         $instance = new TestCasePartialMockObject();
         $instance->init();
@@ -64,7 +69,8 @@ class TestCasePartialMockTest extends TestCase
         $this->assert($this->getProperty($mock, 'foo'), equals, 'bar');
     }
 
-    public function testPartialMockWillInheritPrivateObjectValuesToMaintainState()
+    public function testPartialMockWillInheritPrivateObjectValuesToMaintainState(
+    )
     {
         $instance = new TestCasePartialMockObject();
         $instance->init();

--- a/tests/Concise/TestCasePartialMockTest.php
+++ b/tests/Concise/TestCasePartialMockTest.php
@@ -60,8 +60,7 @@ class TestCasePartialMockTest extends TestCase
         $this->assert($this->getProperty($mock, 'public'), equals, 'yes');
     }
 
-    public function testPartialMockWillInheritProtectedObjectValuesToMaintainState(
-    )
+    public function testPartialMockWillInheritProtectedObjectValuesToMaintainState()
     {
         $instance = new TestCasePartialMockObject();
         $instance->init();
@@ -69,8 +68,7 @@ class TestCasePartialMockTest extends TestCase
         $this->assert($this->getProperty($mock, 'foo'), equals, 'bar');
     }
 
-    public function testPartialMockWillInheritPrivateObjectValuesToMaintainState(
-    )
+    public function testPartialMockWillInheritPrivateObjectValuesToMaintainState()
     {
         $instance = new TestCasePartialMockObject();
         $instance->init();

--- a/tests/Concise/TestCaseTest.php
+++ b/tests/Concise/TestCaseTest.php
@@ -96,14 +96,14 @@ class TestCaseTest extends TestCase
     protected function getAssertionsForFixtureTests()
     {
         $testCase = $this->niceMock('\Concise\TestCase')->stub(
-                array(
-                    'getRawAssertionsForMethod' => array(
-                        'x equals b',
-                        'false',
-                        'true',
-                    )
+            array(
+                'getRawAssertionsForMethod' => array(
+                    'x equals b',
+                    'false',
+                    'true',
                 )
-            )->get();
+            )
+        )->get();
 
         return $testCase->getAssertionsForMethod('abc');
     }

--- a/tests/Concise/TestCaseTest.php
+++ b/tests/Concise/TestCaseTest.php
@@ -2,7 +2,7 @@
 
 namespace Concise;
 
-// This must go outside of any testing code becuase we know that the constants are available before
+    // This must go outside of any testing code becuase we know that the constants are available before
 // test initialisation.
 if (!defined('has_key')) {
     throw new \Exception("Constants not initalised.");
@@ -12,7 +12,11 @@ class TestCaseTest extends TestCase
 {
     public function testExtendsTestCase()
     {
-        $this->assert(new TestCase(), is_an_instance_of, '\PHPUnit_Framework_TestCase');
+        $this->assert(
+            new TestCase(),
+            is_an_instance_of,
+            '\PHPUnit_Framework_TestCase'
+        );
     }
 
     protected function assertAssertions(array $expected, array $actual)
@@ -32,9 +36,9 @@ class TestCaseTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage No such attribute 'noSuchAttribute'.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage No such attribute 'noSuchAttribute'.
+     */
     public function testGetAttributeThatDoesNotExistThrowsException()
     {
         $this->noSuchAttribute;
@@ -62,9 +66,10 @@ class TestCaseTest extends TestCase
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage You cannot assign an attribute with the keyword 'not'.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage You cannot assign an attribute with the
+     *     keyword 'not'.
+     */
     public function testAssigningAnAttributeThatIsAKeywordThrowsAnException()
     {
         $this->not = 123;
@@ -90,15 +95,15 @@ class TestCaseTest extends TestCase
 
     protected function getAssertionsForFixtureTests()
     {
-        $testCase = $this->niceMock('\Concise\TestCase')
-                         ->stub(array(
-                             'getRawAssertionsForMethod' => array(
-                                'x equals b',
-                                'false',
-                                'true',
-                            )
-                         ))
-                         ->get();
+        $testCase = $this->niceMock('\Concise\TestCase')->stub(
+                array(
+                    'getRawAssertionsForMethod' => array(
+                        'x equals b',
+                        'false',
+                        'true',
+                    )
+                )
+            )->get();
 
         return $testCase->getAssertionsForMethod('abc');
     }

--- a/tests/Concise/Validation/ArgumentCheckerTest.php
+++ b/tests/Concise/Validation/ArgumentCheckerTest.php
@@ -8,7 +8,11 @@ class ArgumentCheckerTest extends TestCase
 {
     public function testSuccessReturnsOriginalValue()
     {
-        $this->assert(ArgumentChecker::check(123, 'int', 1), exactly_equals, 123);
+        $this->assert(
+            ArgumentChecker::check(123, 'int', 1),
+            exactly_equals,
+            123
+        );
     }
 
     /**
@@ -31,6 +35,10 @@ class ArgumentCheckerTest extends TestCase
 
     public function testMultipleTypesCanBeCommaSeparated()
     {
-        $this->assert(ArgumentChecker::check(123, 'int,float'), exactly_equals, 123);
+        $this->assert(
+            ArgumentChecker::check(123, 'int,float'),
+            exactly_equals,
+            123
+        );
     }
 }

--- a/tests/Concise/Validation/DataTypeCheckerTest.php
+++ b/tests/Concise/Validation/DataTypeCheckerTest.php
@@ -144,8 +144,7 @@ class DataTypeCheckerTest extends \Concise\TestCase
         );
     }
 
-    public function testWillNotTrimBackslashOffClassIfNotValidatingAgainstClass(
-    )
+    public function testWillNotTrimBackslashOffClassIfNotValidatingAgainstClass()
     {
         $this->assert(
             $this->dataTypeChecker->check(array('string'), '\Concise\TestCase'),

--- a/tests/Concise/Validation/DataTypeCheckerTest.php
+++ b/tests/Concise/Validation/DataTypeCheckerTest.php
@@ -19,12 +19,16 @@ class DataTypeCheckerTest extends \Concise\TestCase
 
     public function testBlankAcceptsAnything()
     {
-        $this->assert($this->dataTypeChecker->check(array(), 123), exactly_equals, 123);
+        $this->assert(
+            $this->dataTypeChecker->check(array(), 123),
+            exactly_equals,
+            123
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 */
+     * @expectedException \Exception
+     */
     public function testSendingValueOfDifferentExpectedTypeThrowsException()
     {
         $this->dataTypeChecker->check(array("int"), 1.23);
@@ -41,7 +45,11 @@ class DataTypeCheckerTest extends \Concise\TestCase
             'array' => array(array("array"), array()),
             'resource' => array(array("resource"), fopen('.', 'r')),
             'object' => array(array("object"), new \stdClass()),
-            'callable' => array(array("callable"), function () {}),
+            'callable' => array(
+                array("callable"),
+                function () {
+                }
+            ),
             'multiple' => array(array("int", "float"), 1.23),
             'regex' => array(array("regex"), new Regexp('abc')),
             'class' => array(array("class"), 'Concise\Syntax\Token\Regexp'),
@@ -51,29 +59,36 @@ class DataTypeCheckerTest extends \Concise\TestCase
             'bool' => array(array("bool"), true),
             'string function' => array(array("string"), 'count'),
             'specific object' => array(array('DateTime'), new DateTime()),
-            'specific object backslash' => array(array('\DateTime'), new DateTime()),
+            'specific object backslash' => array(
+                array('\DateTime'),
+                new DateTime()
+            ),
         );
     }
 
     /**
-	 * @dataProvider dataTypes
-	 */
+     * @dataProvider dataTypes
+     */
     public function testDataTypes(array $types, $value)
     {
-        $this->assert($value, exactly_equals, $this->dataTypeChecker->check($types, $value));
+        $this->assert(
+            $value,
+            exactly_equals,
+            $this->dataTypeChecker->check($types, $value)
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 */
+     * @expectedException \Exception
+     */
     public function testSendingValueNotListedInExpectedTypesThrowsException()
     {
         $this->dataTypeChecker->check(array("int", "string"), 1.23);
     }
 
     /**
-	 * @expectedException \Exception
-	 */
+     * @expectedException \Exception
+     */
     public function testExcludeModeWillNotAllowType()
     {
         $this->dataTypeChecker->setExcludeMode();
@@ -86,13 +101,20 @@ class DataTypeCheckerTest extends \Concise\TestCase
             'foo' => 'bar',
         );
         $this->dataTypeChecker->setContext($context);
-        $this->assert($this->dataTypeChecker->check(array('string'), new Attribute('foo')), exactly_equals, 'bar');
+        $this->assert(
+            $this->dataTypeChecker->check(
+                array('string'),
+                new Attribute('foo')
+            ),
+            exactly_equals,
+            'bar'
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Attribute 'foo' does not exist.
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Attribute 'foo' does not exist.
+     */
     public function testWillThrowExceptionIfAttributeDoesNotExist()
     {
         $this->dataTypeChecker->check(array('string'), new Attribute('foo'));
@@ -106,17 +128,30 @@ class DataTypeCheckerTest extends \Concise\TestCase
 
     public function testWillTrimBackslashOffClass()
     {
-        $this->assert($this->dataTypeChecker->check(array('class'), '\Concise\TestCase'), equals, 'Concise\TestCase');
+        $this->assert(
+            $this->dataTypeChecker->check(array('class'), '\Concise\TestCase'),
+            equals,
+            'Concise\TestCase'
+        );
     }
 
-    public function testWillNotTrimBackslashOffClassIfNotValidatingAgainstClass()
+    public function testWillNotTrimBackslashOffClassIfNotValidatingAgainstClass(
+    )
     {
-        $this->assert($this->dataTypeChecker->check(array('string'), '\Concise\TestCase'), equals, '\Concise\TestCase');
+        $this->assert(
+            $this->dataTypeChecker->check(array('string'), '\Concise\TestCase'),
+            equals,
+            '\Concise\TestCase'
+        );
     }
 
     public function testWillNotTrimBackslashOffClassIfAnyValueCanBeAccepted()
     {
-        $this->assert($this->dataTypeChecker->check(array(), '\Concise\TestCase'), equals, '\Concise\TestCase');
+        $this->assert(
+            $this->dataTypeChecker->check(array(), '\Concise\TestCase'),
+            equals,
+            '\Concise\TestCase'
+        );
     }
 
     public function testWillTrimBackslashOffClassWhenInAttribute()
@@ -125,18 +160,25 @@ class DataTypeCheckerTest extends \Concise\TestCase
             'foo' => '\Concise\TestCase',
         );
         $this->dataTypeChecker->setContext($context);
-        $this->assert($this->dataTypeChecker->check(array('class'), new Attribute('foo')), equals, 'Concise\TestCase');
+        $this->assert(
+            $this->dataTypeChecker->check(array('class'), new Attribute('foo')),
+            equals,
+            'Concise\TestCase'
+        );
     }
 
     public function testStringsWillBeAcceptedForRegex()
     {
-        $this->assertSame('/a/', $this->dataTypeChecker->check(array('regex'), '/a/'));
+        $this->assertSame(
+            '/a/',
+            $this->dataTypeChecker->check(array('regex'), '/a/')
+        );
     }
 
     /**
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Expected regex, but got integer
-	 */
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected regex, but got integer
+     */
     public function testNonStringsWillNotBeAcceptedForRegex()
     {
         $this->dataTypeChecker->check(array('regex'), 123);
@@ -171,7 +213,10 @@ class DataTypeCheckerTest extends \Concise\TestCase
 
     public function testInterfaceIsAllowedForClassName()
     {
-        $result = $this->dataTypeChecker->check(array('class'), '\Concise\Mock\MockInterface');
+        $result = $this->dataTypeChecker->check(
+            array('class'),
+            '\Concise\Mock\MockInterface'
+        );
         $this->assert($result, equals, 'Concise\Mock\MockInterface');
     }
 }

--- a/tests/Concise/Validation/DataTypeMismatchExceptionTest.php
+++ b/tests/Concise/Validation/DataTypeMismatchExceptionTest.php
@@ -8,7 +8,11 @@ class DataTypeMismatchExceptionTest extends TestCase
 {
     public function testIsATypeOfInvalidArgumentException()
     {
-        $this->assert(new DataTypeMismatchException(), instance_of, '\InvalidArgumentException');
+        $this->assert(
+            new DataTypeMismatchException(),
+            instance_of,
+            '\InvalidArgumentException'
+        );
     }
 
     public function testExpectedTypesReturnsArray()
@@ -38,6 +42,10 @@ class DataTypeMismatchExceptionTest extends TestCase
     public function testMessage()
     {
         $e = new DataTypeMismatchException('string', array('int', 'float'));
-        $this->assert($e->getMessage(), equals, 'Expected int or float, but got string');
+        $this->assert(
+            $e->getMessage(),
+            equals,
+            'Expected int or float, but got string'
+        );
     }
 }

--- a/tests/Concise/VerifyFailuresTest.php
+++ b/tests/Concise/VerifyFailuresTest.php
@@ -35,7 +35,11 @@ class VerifyFailuresTest extends TestCase
     {
         $c = new Color();
         self::$failures[] = $this->getName();
-        $this->assert(self::$expectedFailures[$this->getName()], equals, $c($e->getMessage())->clean());
+        $this->assert(
+            self::$expectedFailures[$this->getName()],
+            equals,
+            $c($e->getMessage())->clean()
+        );
     }
 
     public static function tearDownAfterClass()

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -40,17 +40,17 @@ class VersionTest extends TestCase
 
     public function testReturnEmptyStringIfVendorFolderCannotBeFound()
     {
-        $version = $this->niceMock('Concise\Version')
-                        ->stub('findVendorFolder')
-                        ->get();
+        $version =
+            $this->niceMock('Concise\Version')->stub('findVendorFolder')->get();
         $this->assert($version->getConciseVersion(), is_blank);
     }
 
-    public function testFindVendorFolderWillReturnNullIfTheVendorFolderCouldNotBeFound()
+    public function testFindVendorFolderWillReturnNullIfTheVendorFolderCouldNotBeFound(
+    )
     {
-        $version = $this->niceMock('Concise\Version')
-                        ->expose('findVendorFolder')
-                        ->get();
+        $version =
+            $this->niceMock('Concise\Version')->expose('findVendorFolder')->get(
+                );
         $this->assert($version->findVendorFolder('/tmp'), is_null);
     }
 
@@ -61,7 +61,6 @@ class VersionTest extends TestCase
             'unknown version is blank' => array('', ''),
             'version can be prefixed with v' => array('v1.1', 'Dark Matter'),
             'patch version' => array('1.2.3', 'String Theory'),
-
             // Specific versions.
             array('1.0', 'Big Bang'),
             array('1.1', 'Dark Matter'),

--- a/tests/Concise/VersionTest.php
+++ b/tests/Concise/VersionTest.php
@@ -45,12 +45,10 @@ class VersionTest extends TestCase
         $this->assert($version->getConciseVersion(), is_blank);
     }
 
-    public function testFindVendorFolderWillReturnNullIfTheVendorFolderCouldNotBeFound(
-    )
+    public function testFindVendorFolderWillReturnNullIfTheVendorFolderCouldNotBeFound()
     {
         $version =
-            $this->niceMock('Concise\Version')->expose('findVendorFolder')->get(
-                );
+            $this->niceMock('Concise\Version')->expose('findVendorFolder')->get();
         $this->assert($version->findVendorFolder('/tmp'), is_null);
     }
 


### PR DESCRIPTION
Exotic or ActiveRecord types classes keep their properties as only magically accessible. When we cast the object to an array to test for membership they will not show up.