### PR TITLE
Minor result printer cleanup

### DIFF
--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -158,7 +158,7 @@ class DefaultResultPrinter extends AbstractResultPrinter
             $this->width - strlen($assertionString) - strlen($counterString) -
             strlen($time) - strlen($remaining);
 
-        if ($pad < 0) {
+        if ($pad <= 0) {
             return '';
         }
         return sprintf(

--- a/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
+++ b/tests/Concise/Console/ResultPrinter/DefaultResultPrinterTest.php
@@ -2,6 +2,7 @@
 
 namespace Concise\Console\ResultPrinter;
 
+use Concise\Console\ResultPrinter\Utilities\ProgressCounter;
 use Concise\Mock\Invocation;
 use Concise\TestCase;
 use Exception;
@@ -405,5 +406,38 @@ class DefaultResultPrinterTest extends TestCase
         $this->setProperty($resultPrinter, 'width', 80);
 
         $this->assert($resultPrinter->getAssertionString(), equals, 'foo');
+    }
+
+    /**
+     * @group #276
+     */
+    public function testThereIsOneSpaceBetweenTheTimeAndProgress()
+    {
+        $resultPrinter = $this->niceMock(
+            'Concise\Console\ResultPrinter\DefaultResultPrinter'
+        )
+            ->expose('getAssertionString')
+            ->stub(
+                array(
+                    'getTotalTestCount' => 2778,
+                    'getTestCount' => 834,
+                    'getSecondsElapsed' => 500,
+                    'getRemainingSeconds' => 1165,
+                    'getAssertionCount' => 1910,
+                )
+            )
+            ->get();
+        $this->setProperty($resultPrinter, 'width', 80);
+        $this->setProperty(
+            $resultPrinter,
+            'counter',
+            new ProgressCounter(2778, true)
+        );
+
+        $this->assert(
+            $resultPrinter->getAssertionString(),
+            does_not_contain_string,
+            ')8'
+        );
     }
 }

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyStatisticsTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyStatisticsTest.php
@@ -6,6 +6,9 @@ use Concise\TestCase;
 
 class ResultPrinterProxyStatisticsTest extends TestCase
 {
+    /**
+     * @var ResultPrinterProxy
+     */
     protected $proxy;
 
     protected $test;

--- a/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTest.php
+++ b/tests/Concise/Console/ResultPrinter/ResultPrinterProxyTest.php
@@ -6,6 +6,9 @@ use Concise\TestCase;
 
 class ResultPrinterProxyTest extends TestCase
 {
+    /**
+     * @var ResultPrinterProxy
+     */
     protected $proxy;
 
     public function setUp()

--- a/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTest.php
+++ b/tests/Concise/Console/ResultPrinter/Utilities/ProgressBarTest.php
@@ -4,6 +4,9 @@ namespace Concise\Console\ResultPrinter\Utilities;
 
 class ProgressBarTest extends ProgressBarTestCase
 {
+    /**
+     * @var ProgressBar
+     */
     protected $progressBar;
 
     public function setUp()


### PR DESCRIPTION
```
1910 assertions, 8 min 20 sec (19 minutes 25 seconds remaining)834 / 2778 ( 30%)
```

It should leave at least one space between time and tests.