### PR TITLE
$TERM may not be defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 /wiki
 
+doc/_build

--- a/src/Concise/Console/Command.php
+++ b/src/Concise/Console/Command.php
@@ -79,7 +79,8 @@ class Command extends \PHPUnit_TextUI_Command
 
     public function getResultPrinter()
     {
-        if ($this->ci || `tput colors` < 2) {
+        $terminal = new Terminal();
+        if ($this->ci || $terminal->getColors() < 2) {
             return new CIResultPrinter();
         }
 

--- a/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
+++ b/src/Concise/Console/ResultPrinter/DefaultResultPrinter.php
@@ -5,6 +5,7 @@ namespace Concise\Console\ResultPrinter;
 use Concise\Console\ResultPrinter\Utilities\ProgressCounter;
 use Concise\Console\ResultPrinter\Utilities\ProportionalProgressBar;
 use Concise\Console\ResultPrinter\Utilities\RenderIssue;
+use Concise\Console\Terminal;
 use Concise\Console\Theme\DefaultTheme;
 use Concise\Services\TimeFormatter;
 use Exception;
@@ -61,8 +62,8 @@ class DefaultResultPrinter extends AbstractResultPrinter
 
     public function __construct(DefaultTheme $theme = null)
     {
-        /** @noinspection SpellCheckingInspection */
-        $this->width = (int)exec('tput cols');
+        $terminal = new Terminal();
+        $this->width = $terminal->getColumns();
         if (!$theme) {
             $theme = new DefaultTheme();
         }

--- a/src/Concise/Console/Terminal.php
+++ b/src/Concise/Console/Terminal.php
@@ -11,4 +11,12 @@ class Terminal
         }
         return (int)`tput cols`;
     }
+
+    public function getColors()
+    {
+        if (!getenv('TERM')) {
+            return 1;
+        }
+        return (int)`tput colors`;
+    }
 }

--- a/src/Concise/Console/Terminal.php
+++ b/src/Concise/Console/Terminal.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Concise\Console;
+
+class Terminal
+{
+    public function getColumns()
+    {
+        return 0;
+    }
+}

--- a/src/Concise/Console/Terminal.php
+++ b/src/Concise/Console/Terminal.php
@@ -6,6 +6,9 @@ class Terminal
 {
     public function getColumns()
     {
+        if (!getenv('TERM')) {
+            return 80;
+        }
         return (int)`tput cols`;
     }
 }

--- a/src/Concise/Console/Terminal.php
+++ b/src/Concise/Console/Terminal.php
@@ -6,6 +6,6 @@ class Terminal
 {
     public function getColumns()
     {
-        return 0;
+        return (int)`tput cols`;
     }
 }

--- a/tests/Concise/Console/TerminalTest.php
+++ b/tests/Concise/Console/TerminalTest.php
@@ -4,11 +4,20 @@ namespace Concise\Console;
 
 use Concise\TestCase;
 
+/**
+ * @group 275
+ */
 class TerminalTest extends TestCase
 {
-    public function testGetColumns()
+    public function testGetColumnsIsAnInteger()
     {
         $terminal = new Terminal();
         $this->assert($terminal->getColumns(), is_an_integer);
+    }
+
+    public function testGetColumnsFromTheActiveTerminal()
+    {
+        $terminal = new Terminal();
+        $this->assert($terminal->getColumns(), equals, `tput cols`);
     }
 }

--- a/tests/Concise/Console/TerminalTest.php
+++ b/tests/Concise/Console/TerminalTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Concise\Console;
+
+use Concise\TestCase;
+
+class TerminalTest extends TestCase
+{
+    public function testGetColumns()
+    {
+        $terminal = new Terminal();
+        $this->assert($terminal->getColumns(), is_an_integer);
+    }
+}

--- a/tests/Concise/Console/TerminalTest.php
+++ b/tests/Concise/Console/TerminalTest.php
@@ -23,8 +23,31 @@ class TerminalTest extends TestCase
 
     public function testGetColumnsIs80ForUnknownTerminal()
     {
+        $term = getenv('TERM');
         putenv('TERM=');
         $terminal = new Terminal();
         $this->assert($terminal->getColumns(), equals, 80);
+        putenv("TERM=$term");
+    }
+
+    public function testGetColorsIsAnInteger()
+    {
+        $terminal = new Terminal();
+        $this->assert($terminal->getColors(), is_an_integer);
+    }
+
+    public function testGetColorsFromTheActiveTerminal()
+    {
+        $terminal = new Terminal();
+        $this->assert($terminal->getColors(), equals, `tput colors`);
+    }
+
+    public function testGetColorsIs1ForUnknownTerminal()
+    {
+        $term = getenv('TERM');
+        putenv('TERM=');
+        $terminal = new Terminal();
+        $this->assert($terminal->getColors(), equals, 1);
+        putenv("TERM=$term");
     }
 }

--- a/tests/Concise/Console/TerminalTest.php
+++ b/tests/Concise/Console/TerminalTest.php
@@ -20,4 +20,11 @@ class TerminalTest extends TestCase
         $terminal = new Terminal();
         $this->assert($terminal->getColumns(), equals, `tput cols`);
     }
+
+    public function testGetColumnsIs80ForUnknownTerminal()
+    {
+        putenv('TERM=');
+        $terminal = new Terminal();
+        $this->assert($terminal->getColumns(), equals, 80);
+    }
 }


### PR DESCRIPTION
Some CI systems do not have `$TERM` defined.

```bash
$ echo $TERM
xterm-256color
```