### PR TITLE
mock() should disableConstructor()

### DIFF
--- a/doc/creating-mocks.rst
+++ b/doc/creating-mocks.rst
@@ -37,6 +37,10 @@ from a ``\stdClass``:
         ->expect('myMethod')->andReturn(123)
         ->get();
 
+This type of mock does not invoke the constructor since plain mocks are supposed
+to be totally hollow and the constructor could potentially setup an unexpected
+state or call methods that would not have actions associated with them.
+
 Nice Mocks
 ~~~~~~~~~~
 

--- a/src/Concise/Mock/MockBuilder.php
+++ b/src/Concise/Mock/MockBuilder.php
@@ -126,6 +126,10 @@ class MockBuilder
         $this->className = $className;
         $this->niceMock = $niceMock;
         $this->constructorArgs = $constructorArgs;
+
+        if (!$niceMock && !$this->isInterface()) {
+            $this->disableConstructor();
+        }
     }
 
     /**

--- a/tests/Concise/Mock/BuilderConstructorTest.php
+++ b/tests/Concise/Mock/BuilderConstructorTest.php
@@ -28,16 +28,34 @@ class BuilderConstructorTest extends AbstractBuilderTestCase
     }
 
     /**
-     * @dataProvider allBuilders
+     * @dataProvider niceMockBuilders
      */
-    public function testMockReceivesConstructorArguments(
+    public function testNiceMockReceivesConstructorArguments(
         MockBuilder $builder,
         $type
     ) {
         if (self::MOCK_INTERFACE === $type) {
-            return $this->notApplicable();
+            $this->notApplicable();
+            return;
         }
+
         $mock = $builder->get();
         $this->assert($mock->constructorRun, equals, 2);
+    }
+
+    /**
+     * @dataProvider mockBuilders
+     */
+    public function testMockDoesNotEnableConstructorByDefault(
+        MockBuilder $builder,
+        $type
+    ) {
+        if (self::MOCK_INTERFACE === $type) {
+            $this->notApplicable();
+            return;
+        }
+
+        $mock = $builder->get();
+        $this->assert($mock->constructorRun, is_false);
     }
 }

--- a/tests/Concise/Mock/MockBuilderConstructorTest.php
+++ b/tests/Concise/Mock/MockBuilderConstructorTest.php
@@ -33,15 +33,15 @@ class Mock3
  */
 class MockBuilderConstructorTest extends TestCase
 {
-    public function testMocksWillCallConstructorByDefault()
+    public function testNiceMocksWillCallConstructorByDefault()
     {
-        $mock = $this->mock('\Concise\Mock\MockConstructor1')->get();
+        $mock = $this->niceMock('\Concise\Mock\MockConstructor1')->get();
         $this->assert($mock->constructorRun);
     }
 
     public function testDisableConstructorCanBeChained()
     {
-        $mock = $this->mock('\Concise\Mock\MockConstructor1')
+        $mock = $this->niceMock('\Concise\Mock\MockConstructor1')
             ->disableConstructor()
             ->get();
         $this->assert($mock, instance_of, '\Concise\Mock\MockConstructor1');
@@ -49,7 +49,7 @@ class MockBuilderConstructorTest extends TestCase
 
     public function testMocksCanHaveTheirConstructorDisabledWithArguments()
     {
-        $mock = $this->mock('\Concise\Mock\MockConstructor2')
+        $mock = $this->niceMock('\Concise\Mock\MockConstructor2')
             ->disableConstructor()
             ->get();
         $this->assert($mock, instance_of, '\Concise\Mock\MockConstructor2');


### PR DESCRIPTION
A `mock()` is totally empty, so it makes no sense to run the constructor which will possibly invoke methods that will cause the mock build to fail.