### PR TITLE
expose() showing as deprecated

### DIFF
--- a/src/Concise/Mock/MockBuilder.php
+++ b/src/Concise/Mock/MockBuilder.php
@@ -489,10 +489,10 @@ class MockBuilder
 
     /**
      * @throws Exception trying to expose a method on a mock that is not nice.
-     * @internal param $string ... A list of methods to expose.
+     * @param string $string,... A list of methods to expose.
      * @return $this
      */
-    public function expose()
+    public function expose($string)
     {
         if (!$this->niceMock) {
             throw new Exception(


### PR DESCRIPTION
Probably a good idea to get rid of `exposes()` as well. No need for both.