### PR TITLE
getProperty() and setProperty() should allow different classes

### DIFF
--- a/doc/exposing.rst
+++ b/doc/exposing.rst
@@ -109,3 +109,40 @@ Likewise you can use the ``setProperty`` method provided by
        $this->setProperty($myClass, 'value', 'bar');
        $this->assert($this->getProperty($myClass, 'value'))->equals('bar');
    }
+
+``private`` properties are attached to a specific class. Therefore a parent and
+child class can contain ``private`` instance variables by the same name that are
+completely independent.
+
+.. code-block:: php
+
+   class A
+   {
+       private $value = 'foo';
+   }
+
+   class B extends A
+   {
+       private $value = 'bar';
+   }
+
+.. code-block:: php
+
+   public function testPrivates()
+   {
+       $object = new B();
+       $parent = get_parent_class($object);
+
+       $this->getProperty($object, 'value');                 // 'bar'
+       $this->getProperty($object, 'value', $parent);        // 'foo'
+
+       $this->setProperty($object, 'value', 'baz');          // B::$value is set.
+       $this->setProperty($object, 'value', 'baz', $parent); // A::$value is set.
+   }
+
+Concise will automatically determine which class in the hierarchy contains the
+property to be set if no explicit class name is provided. If multiple classes
+contain the same property the most child class is used.
+
+When an explicit class is provided that class is always used whether the
+property exists on that class or not.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,7 @@
         stopOnError="false"
         stopOnFailure="false"
         stopOnIncomplete="false"
-        stopOnSkipped="false"
-        strict="true">
+        stopOnSkipped="false">
     <testsuites>
         <testsuite name="All Tests">
             <directory>tests</directory>

--- a/src/Concise/Core/TestCase.php
+++ b/src/Concise/Core/TestCase.php
@@ -285,6 +285,7 @@ class TestCase extends BaseAssertions
                 throw new Exception($message);
             }
         }
+
         $reflection = new ReflectionClass($className);
         $property = $reflection->getProperty($property);
         $property->setAccessible(true);

--- a/src/Concise/Core/TestCase.php
+++ b/src/Concise/Core/TestCase.php
@@ -257,9 +257,26 @@ class TestCase extends BaseAssertions
         $property,
         $className = null
     ) {
+        // If no class is provided we need to determine which class contains the
+        // property.
         if (null === $className) {
             $className = get_class($object);
+            $reflection = new ReflectionClass($className);
+            while ($reflection) {
+                try {
+                    $reflection->getProperty($property);
+
+                    // If an exception was not thrown then we have found the
+                    // class that contains the property we are looking for so we
+                    // can remeber the class anem and jump out here.
+                    $className = $reflection->getName();
+                    break;
+                } catch (ReflectionException $e) {
+                    $reflection = $reflection->getParentClass();
+                }
+            }
         }
+
         if ($object instanceof MockInterface) {
             $className = get_parent_class($object);
             if (!$className) {

--- a/src/Concise/Core/TestCase.php
+++ b/src/Concise/Core/TestCase.php
@@ -252,9 +252,14 @@ class TestCase extends BaseAssertions
         $this->mockManager->addMockInstance($mockBuilder, $mockInstance);
     }
 
-    protected function getReflectionProperty($object, $property)
-    {
-        $className = get_class($object);
+    protected function getReflectionProperty(
+        $object,
+        $property,
+        $className = null
+    ) {
+        if (null === $className) {
+            $className = get_class($object);
+        }
         if ($object instanceof MockInterface) {
             $className = get_parent_class($object);
             if (!$className) {
@@ -276,10 +281,14 @@ class TestCase extends BaseAssertions
         method_exists($object, '__get');
     }
 
-    public function getProperty($object, $property)
+    public function getProperty($object, $property, $class = null)
     {
         try {
-            $property = $this->getReflectionProperty($object, $property);
+            $property = $this->getReflectionProperty(
+                $object,
+                $property,
+                $class
+            );
             return $property->getValue($object);
         } catch (ReflectionException $e) {
             if ($this->shouldAccessProperty($object, $property)) {
@@ -290,10 +299,10 @@ class TestCase extends BaseAssertions
         }
     }
 
-    public function setProperty($object, $name, $value)
+    public function setProperty($object, $name, $value, $class = null)
     {
         try {
-            $property = $this->getReflectionProperty($object, $name);
+            $property = $this->getReflectionProperty($object, $name, $class);
             $property->setValue($object, $value);
         } catch (ReflectionException $e) {
             $object->$name = $value;

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -20,11 +20,9 @@ class MagicProperty
 
 class ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */
-        $a = 1;
+    private $a = 1;
 
-    private /** @noinspection PhpUnusedPrivateFieldInspection */
-        $c = 4;
+    private $c = 4;
 
     public function a()
     {
@@ -39,11 +37,9 @@ class ParentClass
 
 class ChildClass extends ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */
-        $a = 2;
+    private $a = 2;
 
-    private /** @noinspection PhpUnusedPrivateFieldInspection */
-        $b = 3;
+    private $b = 3;
 
     public function a()
     {

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -30,7 +30,14 @@ class ParentClass
 
 class ChildClass extends ParentClass
 {
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a;
+
     private /** @noinspection PhpUnusedPrivateFieldInspection */ $b;
+
+    public function a()
+    {
+        return $this->a;
+    }
 
     public function b()
     {
@@ -251,7 +258,17 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
     public function testPrivatePropertyIsSetOnChildClassByDefault()
     {
         $object = new ChildClass();
-        $this->setProperty($object, 'b', 'foo');
-        $this->assert($object->b())->equals('foo');
+        $this->setProperty($object, 'a', 'foo');
+        $this->assert($object->a())->equals('foo');
+    }
+
+    /**
+     * @group #309
+     */
+    public function testPrivatePropertyCanBeSetOnAnExplicitClass()
+    {
+        $object = new ChildClass();
+        $this->setProperty($object, 'a', 'foo', get_parent_class($object));
+        $this->assert($object->a())->isNull;
     }
 }

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -20,9 +20,11 @@ class MagicProperty
 
 class ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a = 1;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */
+        $a = 1;
 
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $c = 4;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */
+        $c = 4;
 
     public function a()
     {
@@ -37,9 +39,11 @@ class ParentClass
 
 class ChildClass extends ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a = 2;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */
+        $a = 2;
 
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $b = 3;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */
+        $b = 3;
 
     public function a()
     {
@@ -296,5 +300,18 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
     {
         $object = new ChildClass();
         $this->assert($this->getProperty($object, 'a'))->equals(2);
+    }
+
+    /**
+     * @group #309
+     */
+    public function testSetAmbiguousPrivatePropertyUsesChildClass()
+    {
+        $object = new ChildClass();
+        $this->setProperty($object, 'a', 'foo');
+        $this->assert($this->getProperty($object, 'a'))->equals('foo');
+        $this->assert(
+            $this->getProperty($object, 'a', get_parent_class($object))
+        )->equals(1);
     }
 }

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -20,19 +20,26 @@ class MagicProperty
 
 class ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a = 1;
+
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $c = 4;
 
     public function a()
     {
         return $this->a;
     }
+
+    public function c()
+    {
+        return $this->c;
+    }
 }
 
 class ChildClass extends ParentClass
 {
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a = 2;
 
-    private /** @noinspection PhpUnusedPrivateFieldInspection */ $b;
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $b = 3;
 
     public function a()
     {
@@ -269,6 +276,16 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
     {
         $object = new ChildClass();
         $this->setProperty($object, 'a', 'foo', get_parent_class($object));
-        $this->assert($object->a())->isNull;
+        $this->assert($object->a())->equals(2);
+    }
+
+    /**
+     * @group #309
+     */
+    public function testPrivatePropertyOnlyOnParentClassWillBeSet()
+    {
+        $object = new ChildClass();
+        $this->setProperty($object, 'c', 'foo');
+        $this->assert($object->c())->equals('foo');
     }
 }

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -18,6 +18,26 @@ class MagicProperty
     }
 }
 
+class ParentClass
+{
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $a;
+
+    public function a()
+    {
+        return $this->a;
+    }
+}
+
+class ChildClass extends ParentClass
+{
+    private /** @noinspection PhpUnusedPrivateFieldInspection */ $b;
+
+    public function b()
+    {
+        return $this->b;
+    }
+}
+
 /**
  * @group mocking
  */
@@ -223,5 +243,15 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
         $object = new MagicProperty();
         $this->setProperty($object, 'foo', 'bar');
         $this->assert($this->getProperty($object, 'foo'))->equals('bar');
+    }
+
+    /**
+     * @group #309
+     */
+    public function testPrivatePropertyIsSetOnChildClassByDefault()
+    {
+        $object = new ChildClass();
+        $this->setProperty($object, 'b', 'foo');
+        $this->assert($object->b())->equals('foo');
     }
 }

--- a/tests/Concise/Mock/BuilderPropertyTest.php
+++ b/tests/Concise/Mock/BuilderPropertyTest.php
@@ -288,4 +288,13 @@ class BuilderPropertyTest extends AbstractBuilderTestCase
         $this->setProperty($object, 'c', 'foo');
         $this->assert($object->c())->equals('foo');
     }
+
+    /**
+     * @group #309
+     */
+    public function testGetAmbiguousPrivatePropertyReturnsChildClass()
+    {
+        $object = new ChildClass();
+        $this->assert($this->getProperty($object, 'a'))->equals(2);
+    }
 }


### PR DESCRIPTION
When setting and getting private properties of a class it will only operate on the child class, but since private is local to the class itself the variable you wish to set or get might be up the chain.