### PR TITLE
ClassCompiler::setCustomClassName() should not load the class

### DIFF
--- a/src/Concise/Mock/ClassCompiler.php
+++ b/src/Concise/Mock/ClassCompiler.php
@@ -438,7 +438,7 @@ EOF;
                 "Invalid class name '$className'."
             );
         }
-        if (class_exists($className)) {
+        if (class_exists($className, false)) {
             throw new InvalidArgumentException(
                 "You cannot use '$className' because a class with that name already exists."
             );

--- a/tests/Concise/Mock/BuilderCustomClassNameTest.php
+++ b/tests/Concise/Mock/BuilderCustomClassNameTest.php
@@ -2,6 +2,10 @@
 
 namespace Concise\Mock;
 
+class FooClass
+{
+}
+
 /**
  * @group mocking
  */
@@ -26,5 +30,16 @@ class BuilderCustomClassNameTest extends AbstractBuilderTestCase
         $rand = "Concise\\Mock\\Temp" . md5(rand());
         $mock = $builder->setCustomClassName($rand)->get();
         $this->assert(get_class($mock))->equals($rand);
+    }
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You cannot use 'Concise\Mock\FooClass' because a class with that name already exists.
+     * @dataProvider allBuilders
+     * @group #304
+     */
+    public function testWillThrowExceptionIfTheCustomNameAlreadyExists(
+        MockBuilder $builder
+    ) {
+        $builder->setCustomClassName('Concise\Mock\FooClass')->get();
     }
 }

--- a/tests/Concise/Mock/BuilderCustomClassNameTest.php
+++ b/tests/Concise/Mock/BuilderCustomClassNameTest.php
@@ -31,9 +31,11 @@ class BuilderCustomClassNameTest extends AbstractBuilderTestCase
         $mock = $builder->setCustomClassName($rand)->get();
         $this->assert(get_class($mock))->equals($rand);
     }
+
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot use 'Concise\Mock\FooClass' because a class with that name already exists.
+     * @expectedExceptionMessage You cannot use 'Concise\Mock\FooClass' because
+     *     a class with that name already exists.
      * @dataProvider allBuilders
      * @group #304
      */
@@ -41,5 +43,25 @@ class BuilderCustomClassNameTest extends AbstractBuilderTestCase
         MockBuilder $builder
     ) {
         $builder->setCustomClassName('Concise\Mock\FooClass')->get();
+    }
+
+    /**
+     * @dataProvider allBuilders
+     * @group #304
+     */
+    public function testCustomClassNameWillNotActivateClassLoader(
+        MockBuilder $builder
+    ) {
+        spl_autoload_register(
+            function () {
+                throw new \Exception("Autoloader should not have been called.");
+            }
+        );
+
+        $rand = "Concise\\Mock\\Temp" . md5(rand());
+        $builder->setCustomClassName($rand)->get();
+
+        $functions = spl_autoload_functions();
+        spl_autoload_unregister($functions[count($functions) - 1]);
     }
 }


### PR DESCRIPTION
`ClassCompiler::setCustomClassName()` tests if the class already exists however it should turn off the autoloader otherwise horrible things will happen.