### PR TITLE
DidNotMatchException() used in some assertions

### DIFF
--- a/src/Concise/Core/AssertionBuilder.php
+++ b/src/Concise/Core/AssertionBuilder.php
@@ -92,7 +92,7 @@ class AssertionBuilder
                 $instance->{$syntax->getMethod()}();
                 $this->testCase->assertTrue(true);
             } catch (DidNotMatchException $e) {
-                $this->handleFailure($e);
+                $this->handleFailure($e, $instance);
             }
         }
 
@@ -120,26 +120,27 @@ class AssertionBuilder
     }
 
     /**
-     * @param Exception $e
-     * @throws DidNotMatchException
-     * @throws Exception
+     * @param Exception      $e
+     * @param AbstractModule $module
      */
-    public function handleFailure(Exception $e)
+    public function handleFailure(Exception $e, AbstractModule $module = null)
     {
         if ($this->verify) {
             $this->testCase->verifyFailures[] = $e->getMessage();
         } else {
+            $message = '';
             if ($this->failureMessage) {
-                throw new PHPUnit_Framework_AssertionFailedError(
-                    $this->failureMessage
+                $message = $this->failureMessage;
+            } elseif ($e->getMessage()) {
+                $message = $e->getMessage();
+            } elseif ($module) {
+                $message = $module->renderFailureMessage(
+                    $module->syntax->getRawSyntax(),
+                    $module->data
                 );
             }
-            if ($e->getMessage()) {
-                throw new PHPUnit_Framework_AssertionFailedError(
-                    $e->getMessage()
-                );
-            }
-            throw $e;
+
+            throw new PHPUnit_Framework_AssertionFailedError($message);
         }
     }
 

--- a/src/Concise/Core/AssertionBuilder.php
+++ b/src/Concise/Core/AssertionBuilder.php
@@ -4,6 +4,7 @@ namespace Concise\Core;
 
 use Concise\Module\AbstractModule;
 use Exception;
+use PHPUnit_Framework_AssertionFailedError;
 
 class AssertionBuilder
 {
@@ -121,14 +122,17 @@ class AssertionBuilder
     /**
      * @param Exception $e
      * @throws DidNotMatchException
+     * @throws Exception
      */
-    protected function handleFailure(Exception $e)
+    public function handleFailure(Exception $e)
     {
         if ($this->verify) {
             $this->testCase->verifyFailures[] = $e->getMessage();
         } else {
             if ($this->failureMessage) {
-                throw new DidNotMatchException($this->failureMessage);
+                throw new PHPUnit_Framework_AssertionFailedError(
+                    $this->failureMessage
+                );
             }
             throw $e;
         }

--- a/src/Concise/Core/AssertionBuilder.php
+++ b/src/Concise/Core/AssertionBuilder.php
@@ -134,6 +134,11 @@ class AssertionBuilder
                     $this->failureMessage
                 );
             }
+            if ($e->getMessage()) {
+                throw new PHPUnit_Framework_AssertionFailedError(
+                    $e->getMessage()
+                );
+            }
             throw $e;
         }
     }

--- a/src/Concise/Core/AssertionBuilder.php
+++ b/src/Concise/Core/AssertionBuilder.php
@@ -4,7 +4,6 @@ namespace Concise\Core;
 
 use Concise\Module\AbstractModule;
 use Exception;
-use PHPUnit_Framework_AssertionFailedError;
 
 class AssertionBuilder
 {
@@ -125,22 +124,22 @@ class AssertionBuilder
      */
     public function handleFailure(Exception $e, AbstractModule $module = null)
     {
-        if ($this->verify) {
-            $this->testCase->verifyFailures[] = $e->getMessage();
-        } else {
-            $message = '';
-            if ($this->failureMessage) {
-                $message = $this->failureMessage;
-            } elseif ($e->getMessage()) {
-                $message = $e->getMessage();
-            } elseif ($module) {
-                $message = $module->renderFailureMessage(
-                    $module->syntax->getRawSyntax(),
-                    $module->data
-                );
-            }
+        $message = '';
+        if ($this->failureMessage) {
+            $message = $this->failureMessage;
+        } elseif ($e->getMessage()) {
+            $message = $e->getMessage();
+        } elseif ($module) {
+            $message = $module->renderFailureMessage(
+                $module->syntax->getRawSyntax(),
+                $module->data
+            );
+        }
 
-            throw new PHPUnit_Framework_AssertionFailedError($message);
+        if ($this->verify) {
+            $this->testCase->verifyFailures[] = $message;
+        } else {
+            throw new DidNotMatchException($message);
         }
     }
 

--- a/src/Concise/Core/TestCase.php
+++ b/src/Concise/Core/TestCase.php
@@ -168,7 +168,9 @@ class TestCase extends BaseAssertions
         if ($this->verifyFailures) {
             $count = count($this->verifyFailures);
             $message =
-                "$count verify failure" . ($count === 1 ? '' : 's') . ":";
+                "$count verify failure" .
+                ($count === 1 ? '' : 's') .
+                ":";
             $message .= "\n\n" . implode("\n\n", $this->verifyFailures);
             throw new PHPUnit_Framework_AssertionFailedError($message);
         }

--- a/src/Concise/Module/AbstractModule.php
+++ b/src/Concise/Module/AbstractModule.php
@@ -95,12 +95,7 @@ abstract class AbstractModule
 
     protected function fail()
     {
-        throw new DidNotMatchException(
-            $this->renderFailureMessage(
-                $this->syntax->getRawSyntax(),
-                $this->data
-            )
-        );
+        throw new DidNotMatchException();
     }
 
     protected function failIf($test)

--- a/tests/Concise/Core/AssertionBuilderTest.php
+++ b/tests/Concise/Core/AssertionBuilderTest.php
@@ -19,7 +19,7 @@ class AssertionBuilderTest extends TestCase
                 new Exception('foo bar'),
                 $this->getBasicModule()
             );
-        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (DidNotMatchException $e) {
             $this->assert($e->getMessage())->equals('custom message');
         }
     }
@@ -35,7 +35,7 @@ class AssertionBuilderTest extends TestCase
                 new Exception('foo bar'),
                 $this->getBasicModule()
             );
-        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (DidNotMatchException $e) {
             $this->assert($e->getMessage())->equals('foo bar');
         }
     }
@@ -51,7 +51,7 @@ class AssertionBuilderTest extends TestCase
                 new DidNotMatchException(),
                 $this->getBasicModule()
             );
-        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (DidNotMatchException $e) {
             $this->assert($e->getMessage())->equals('my syntax');
         }
     }

--- a/tests/Concise/Core/AssertionBuilderTest.php
+++ b/tests/Concise/Core/AssertionBuilderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Concise\Core;
+
+use Exception;
+use PHPUnit_Framework_AssertionFailedError;
+
+class AssertionBuilderTest extends TestCase
+{
+    /**
+     * @group #306
+     */
+    public function testHandleFailureWillUseCustomFailureMessageFirst()
+    {
+        try {
+            /** @var AssertionBuilder $builder */
+            $builder = $this->niceMock(
+                '\Concise\Core\AssertionBuilder',
+                array($this, 'custom message')
+            )
+                ->setProperty('lastBuilder', null)
+                ->stub('validateLastAssertion')
+                ->get();
+            $builder->handleFailure(new Exception('foo bar'));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            $this->assert($e->getMessage())->equals('custom message');
+        }
+    }
+}

--- a/tests/Concise/Core/AssertionBuilderTest.php
+++ b/tests/Concise/Core/AssertionBuilderTest.php
@@ -26,4 +26,24 @@ class AssertionBuilderTest extends TestCase
             $this->assert($e->getMessage())->equals('custom message');
         }
     }
+
+    /**
+     * @group #306
+     */
+    public function testDidNotMatchExceptionMessageIfNoCustomFailureMessage()
+    {
+        try {
+            /** @var AssertionBuilder $builder */
+            $builder = $this->niceMock(
+                '\Concise\Core\AssertionBuilder',
+                array($this)
+            )
+                ->setProperty('lastBuilder', null)
+                ->stub('validateLastAssertion')
+                ->get();
+            $builder->handleFailure(new Exception('foo bar'));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            $this->assert($e->getMessage())->equals('foo bar');
+        }
+    }
 }

--- a/tests/Concise/Core/AssertionBuilderTest.php
+++ b/tests/Concise/Core/AssertionBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Concise\Core;
 
+use Concise\Module\BasicModule;
 use Exception;
 use PHPUnit_Framework_AssertionFailedError;
 
@@ -13,15 +14,11 @@ class AssertionBuilderTest extends TestCase
     public function testHandleFailureWillUseCustomFailureMessageFirst()
     {
         try {
-            /** @var AssertionBuilder $builder */
-            $builder = $this->niceMock(
-                '\Concise\Core\AssertionBuilder',
-                array($this, 'custom message')
-            )
-                ->setProperty('lastBuilder', null)
-                ->stub('validateLastAssertion')
-                ->get();
-            $builder->handleFailure(new Exception('foo bar'));
+            $builder = $this->getBuilder(array($this, 'custom message'));
+            $builder->handleFailure(
+                new Exception('foo bar'),
+                $this->getBasicModule()
+            );
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             $this->assert($e->getMessage())->equals('custom message');
         }
@@ -33,17 +30,57 @@ class AssertionBuilderTest extends TestCase
     public function testDidNotMatchExceptionMessageIfNoCustomFailureMessage()
     {
         try {
-            /** @var AssertionBuilder $builder */
-            $builder = $this->niceMock(
-                '\Concise\Core\AssertionBuilder',
-                array($this)
-            )
-                ->setProperty('lastBuilder', null)
-                ->stub('validateLastAssertion')
-                ->get();
-            $builder->handleFailure(new Exception('foo bar'));
+            $builder = $this->getBuilder(array($this));
+            $builder->handleFailure(
+                new Exception('foo bar'),
+                $this->getBasicModule()
+            );
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             $this->assert($e->getMessage())->equals('foo bar');
         }
+    }
+
+    /**
+     * @group #306
+     */
+    public function testWillRenderSyntaxIsNoOtherMessageCanBeFound()
+    {
+        try {
+            $builder = $this->getBuilder(array($this));
+            $builder->handleFailure(
+                new DidNotMatchException(),
+                $this->getBasicModule()
+            );
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            $this->assert($e->getMessage())->equals('my syntax');
+        }
+    }
+
+    /**
+     * @return BasicModule
+     */
+    protected function getBasicModule()
+    {
+        $module = new BasicModule();
+        $module->syntax = new Syntax('my syntax');
+        $module->data = array();
+        return $module;
+    }
+
+    /**
+     * @return AssertionBuilder
+     * @throws Exception
+     */
+    protected function getBuilder(array $constructorArgs)
+    {
+        /** @var AssertionBuilder $builder */
+        $builder = $this->niceMock(
+            '\Concise\Core\AssertionBuilder',
+            $constructorArgs
+        )
+            ->setProperty('lastBuilder', null)
+            ->stub('validateLastAssertion')
+            ->get();
+        return $builder;
     }
 }


### PR DESCRIPTION
The date and time module uses a raw `throw new DidNotMatchException()` which will show no message on failure. We should move the logic for rendering the error message out of the module itself and a blank DidNotMatchException will just render the default message.