### PR TITLE
Don't change the access level of setUp() and tearDown()

### DIFF
--- a/src/Concise/Core/TestCase.php
+++ b/src/Concise/Core/TestCase.php
@@ -140,7 +140,7 @@ abstract class TestCase extends BaseAssertions
     /**
      * @return void
      */
-    public function tearDown()
+    protected function tearDown()
     {
         AssertionBuilder::validateLastAssertion();
         $this->mockManager->validateMocks();
@@ -221,7 +221,7 @@ abstract class TestCase extends BaseAssertions
         }
     }
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->verifyFailures = array();

--- a/tests/Concise/Core/TestCaseExternalTest.php
+++ b/tests/Concise/Core/TestCaseExternalTest.php
@@ -16,23 +16,17 @@ class MyTinyTestSuite
 
     public function checkSomething()
     {
-        $this->testCase->setUp();
         $this->testCase->assert(3 + 5)->equals(8);
-        $this->testCase->tearDown();
     }
 
     public function checkSomethingElse()
     {
-        $this->testCase->setUp();
         $this->testCase->assert(3 + 5)->equals(7);
-        $this->testCase->tearDown();
     }
 
     public function checkSomethingAgain()
     {
-        $this->testCase->setUp();
         $this->testCase->assert(3 + 5)->equals(8);
-        $this->testCase->tearDown();
     }
 }
 


### PR DESCRIPTION
PHPUnit has these as protected, as has most of our test suite. Switching our base testcase class would require changing all our (thousands of) protected setUp() and tearDown() methods to public.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/concise/340)

<!-- Reviewable:end -->
