### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+/.gitignore export-ignore
+/.gitmodules export-ignore
+/.gitattributes export-ignore
+/.idea export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/build export-ignore
+/doc export-ignore
+/scripts export-ignore
+/composer.lock
+/phpunit.xml
+/tests export-ignore


### PR DESCRIPTION
Don't distribute tests, build files etc. when installing with Composer with --prefer-dist (the default). This saves lots of bandwith and file extraction when installing dependencies with default settings.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/concise/341)

<!-- Reviewable:end -->
