### PR TITLE
Add support for PHP 7 return type declarations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "bin": [ "bin/concise", "bin/concise-init" ],
     "require": {
         "php": ">=5.3.9",
-        "phpunit/phpunit": ">= 4.0",
+        "phpunit/phpunit": "~5.0",
         "kevinlebrun/colors.php": ">= 0.3.0"
     },
     "require-dev": {

--- a/src/Concise/Mock/PrototypeBuilder.php
+++ b/src/Concise/Mock/PrototypeBuilder.php
@@ -6,6 +6,7 @@ use Concise\Core\ArgumentChecker;
 use Reflection;
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionType;
 
 class PrototypeBuilder
 {
@@ -53,6 +54,20 @@ class PrototypeBuilder
         return $param;
     }
 
+    protected function getReturnType(ReflectionMethod $method)
+    {
+        if ($method->hasReturnType()) {
+            $returnType = $method->getReturnType();
+            if ($returnType->isBuiltin()) {
+                return ' : ' . $method->getReturnType();
+            } else {
+                return ' : \\' . $method->getReturnType();
+            }
+        }
+
+        return '';
+    }
+
     /**
      * Get the prototype for the method.
      *
@@ -74,8 +89,10 @@ class PrototypeBuilder
             $parameters[] = $param;
         }
 
+        $returnType = $this->getReturnType($method);
+
         return $modifiers . ' function ' . $method->getName() . "(" .
-        implode(', ', $parameters) . ")";
+        implode(', ', $parameters) . ")" . $returnType;
     }
 
     /**


### PR DESCRIPTION
Concise isn't able to mock functions in PHP 7 that have a return type declared.  This change supports that by using reflection to find the return type and appending it to the function prototype.  It supports both primitives and classes.  I'm kind of a PHP newbie, so I might be missing some edge case, but it seems to work so far.